### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  register:
+    name: Package, Publish, and Register
+    runs-on:
+      - ubuntu-20.04 # ubuntu-latest currently resolves to 18.04 which does not have aws-cli 2.x yet
+    strategy:
+      matrix:
+        include:
+          - buildpack-path: "meta-buildpacks/java"
+            package: "public.ecr.aws/r2f9u0w4/heroku-java-buildpack"
+    env:
+      BUILDPACK_PATH: ${{ matrix.buildpack-path }}
+      PACKAGE: ${{ matrix.package }}
+    steps:
+      - id: checkout
+        name: Checkout code
+        uses: actions/checkout@v2
+      - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+        name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+      - id: setup-pack
+        name: Package Buildpack
+        uses: buildpacks/github-actions/setup-pack@v4.0.0
+      - id: package
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          ID="$(cat ${BUILDPACK_PATH}/buildpack.toml | yj -t | jq -r .buildpack.id)"
+          VERSION="$(cat ${BUILDPACK_PATH}/buildpack.toml | yj -t | jq -r .buildpack.version)"
+          pack package-buildpack --config ${BUILDPACK_PATH}/package.toml --publish ${PACKAGE}:${VERSION}
+          DIGEST="$(crane digest ${PACKAGE}:${VERSION})"
+
+          echo "::set-output name=id::$ID"
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=address::${PACKAGE}@${DIGEST}"
+        shell: bash
+      - id: register
+        name: Register Buildpack
+        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.0
+        with:
+          token: ${{ secrets.PUBLIC_REPO_TOKEN }}
+          id: ${{ steps.package.outputs.id }}
+          version: ${{ steps.package.outputs.version }}
+          address: ${{ steps.package.outputs.address }}


### PR DESCRIPTION
This workflow builds, packages, and releases CNBs to the official registry whenever a new release is published on GitHub. This still has some rough edges and no clear plan of what to do when this repo becomes a monorepo. We'll cross the bridge when we get there.

Closes [W-8666346](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008w12QIAQ/view)