### PR TITLE
Update buildpack versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - pack/install-pack
+      - pack/install-pack:
+          version: 0.16.0
       - run: pack package-buildpack test --config << parameters.package-toml >>
 
 workflows:

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -1,31 +1,30 @@
-api = "0.2"
+api = "0.4"
 
 [buildpack]
 id = "heroku/java"
-version = "0.1"
+version = "0.1.1"
 name = "Java"
 
 [[order]]
 [[order.group]]
 id = "heroku/jvm"
-version = "0.1"
+version = "0.1.0"
 
 [[order.group]]
 id = "heroku/maven"
-version = "0.1"
+version = "0.1.0"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6"
+version = "0.6.1"
 optional = true
 
 [[order]]
 [[order.group]]
 id = "heroku/gradle"
-version = "0.3"
+version = "0.4.0"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "0.6"
+version = "0.6.1"
 optional = true
-

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -2,13 +2,14 @@
 uri = "."
 
 [[dependencies]]
-uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
+uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v115/heroku-jvm-common-cnb-v115.tgz"
 
 [[dependencies]]
-uri = "https://github.com/heroku/heroku-buildpack-java/releases/download/v68/heroku-java-cnb-v68.tgz"
+uri = "https://github.com/heroku/heroku-buildpack-java/releases/download/v69/heroku-java-cnb-v69.tgz"
 
 [[dependencies]]
-uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.3&name=Gradle"
+uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.4.0&name=Gradle"
 
 [[dependencies]]
-uri = "https://github.com/heroku/procfile-cnb/releases/download/v0.6/procfile-cnb-v0.6.tgz"
+# Should be urn:cnb:registry:heroku/procfile@0.6.1 as soon as pack supports it. (0.16.1?)
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:74881b33e1e33eea38b419e667b0a99ac50e536727eeefd1b2eeb7ff3a937ffd"


### PR DESCRIPTION
Updates all buildpack versions used by `heroku/java`. Many of them used an illegal schema `x.y` instead of `x.y.z`.

Skipping changelog since there hasn't been a release yet.