### PR TITLE
Shimmed Buildpacks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,21 @@ jobs:
             buildpack_version="$(yj -t < "${buildpack_toml_path}" | jq -r .buildpack.version)"
             buildpack_docker_repository="$(yj -t < "${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"
             buildpack_path=$(dirname "${buildpack_toml_path}")
+            buildpack_shim_v2_tarball="$(yj -t < "${buildpack_toml_path}" | jq -r .metadata.shim_v2_tarball)"
 
             if [[ $buildpack_id == "${REQUESTED_BUILDPACK_ID}" ]]; then
-              image_name="${buildpack_docker_repository}:${buildpack_version}"
+              # If the buildpack has a V2 buildpack tarball in its metadata it's supposed to be a shimmed buildpack.
+              # We download the shim and the V2 buildpack to the buildpack directory, turning it into a CNB. This transformation
+              # is transparent for the code that follows after it.
+              if [[ -n "${buildpack_shim_v2_tarball:-}" ]]; then
+                cnb_shim_tarball_curl="https://github.com/heroku/cnb-shim/releases/download/v0.3/cnb-shim-v0.3.tgz"
+                mkdir -p "${buildpack_path}/target"
 
+                curl --retry 3 --location "${cnb_shim_tarball_curl}" | tar -xzm -C "${buildpack_path}"
+                curl --retry 3 --location "${buildpack_shim_v2_tarball}" | tar -xzm -C "${buildpack_path}/target"
+              fi
+
+              image_name="${buildpack_docker_repository}:${buildpack_version}"
               pack package-buildpack --config "${buildpack_path}/package.toml" --publish "${image_name}"
 
               echo "::set-output name=id::${buildpack_id}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,22 +35,40 @@ jobs:
           set -euo pipefail
 
           while IFS="" read -r -d "" buildpack_toml_path; do
-            buildpack_id="$(yj -t < "${buildpack_toml_path}" | jq -r .buildpack.id)"
-            buildpack_version="$(yj -t < "${buildpack_toml_path}" | jq -r .buildpack.version)"
-            buildpack_docker_repository="$(yj -t < "${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"
+            buildpack_id="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.id)"
+            buildpack_version="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.version)"
+            buildpack_docker_repository="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"
             buildpack_path=$(dirname "${buildpack_toml_path}")
-            buildpack_shim_v2_tarball="$(yj -t < "${buildpack_toml_path}" | jq -r .metadata.shim_v2_tarball)"
 
             if [[ $buildpack_id == "${REQUESTED_BUILDPACK_ID}" ]]; then
+              cnb_shim_tarball_url="https://github.com/heroku/cnb-shim/releases/download/v0.3/cnb-shim-v0.3.tgz"
+              cnb_shim_tarball_sha256="109cfc01953cb04e69c82eec1c45c7c800bd57d2fd0eef030c37d8fc37a1cb4d"
+              local_cnb_shim_tarball=$(mktemp)
+
+              v2_buildpack_tarball_url="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.shim.tarball)"
+              v2_buildpack_tarball_sha256="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.shim.sha256)"
+              local_v2_buildpack_tarball=$(mktemp)
+
               # If the buildpack has a V2 buildpack tarball in its metadata it's supposed to be a shimmed buildpack.
               # We download the shim and the V2 buildpack to the buildpack directory, turning it into a CNB. This transformation
               # is transparent for the code that follows after it.
-              if [[ -n "${buildpack_shim_v2_tarball:-}" ]]; then
-                cnb_shim_tarball_curl="https://github.com/heroku/cnb-shim/releases/download/v0.3/cnb-shim-v0.3.tgz"
-                mkdir -p "${buildpack_path}/target"
+              if [[ -n "${v2_buildpack_tarball_url:-}" ]]; then
+                curl --retry 3 --location "${cnb_shim_tarball_url}" --output "${local_cnb_shim_tarball}"
+                curl --retry 3 --location "${v2_buildpack_tarball_url}" --output "${local_v2_buildpack_tarball}"
 
-                curl --retry 3 --location "${cnb_shim_tarball_curl}" | tar -xzm -C "${buildpack_path}"
-                curl --retry 3 --location "${buildpack_shim_v2_tarball}" | tar -xzm -C "${buildpack_path}/target"
+                if ! echo "${cnb_shim_tarball_sha256} ${local_cnb_shim_tarball}" | sha256sum --check --status; then
+                  echo "Checksum verification of cnb_shim failed!"
+                  exit 1
+                fi
+
+                if ! echo "${v2_buildpack_tarball_sha256} ${local_v2_buildpack_tarball}" | sha256sum --check --status; then
+                  echo "Checksum verification of V2 buildpack tarball failed!"
+                  exit 1
+                fi
+
+                mkdir -p "${buildpack_path}/target"
+                tar -xzmf "${local_cnb_shim_tarball}" -C "${buildpack_path}"
+                tar -xzmf "${local_v2_buildpack_tarball}" -C "${buildpack_path}/target"
               fi
 
               image_name="${buildpack_docker_repository}:${buildpack_version}"

--- a/shimmed-buildpacks/clojure/CHANGELOG.md
+++ b/shimmed-buildpacks/clojure/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+## main
+
+## 0.0.86
+This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
+for that release can be found here: https://github.com/heroku/heroku-buildpack-clojure/blob/main/CHANGELOG.md#v86

--- a/shimmed-buildpacks/clojure/README.md
+++ b/shimmed-buildpacks/clojure/README.md
@@ -1,0 +1,8 @@
+#  Heroku Cloud Native Clojure Buildpack
+
+Note: This is not a _native_ Cloud Native Buildpack yet. Releases of this buildpack are created by shimming classic
+[Heroku Clojure buildpack](https://github.com/heroku/heroku-buildpack-clojure) releases via
+[cnb-shim](https://github.com/heroku/cnb-shim).
+
+The code in this directory will only turn into a valid buildpack during the release process. To use this buildpack, use
+the release on the official Cloud Native Buildpack registry.

--- a/shimmed-buildpacks/clojure/buildpack.toml
+++ b/shimmed-buildpacks/clojure/buildpack.toml
@@ -14,8 +14,9 @@ id = "heroku-20"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
-shim_v2_tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/clojure-v86.tgz"
+[metadata.shim]
+tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/clojure-v86.tgz"
+sha256="c85cb7f4e10a2bc76fc9804d14842ea1021609a23d953359eed30cfd019560d1"
 
 [metadata.release.docker]
 repository="public.ecr.aws/r2f9u0w4/heroku-clojure-buildpack"

--- a/shimmed-buildpacks/clojure/buildpack.toml
+++ b/shimmed-buildpacks/clojure/buildpack.toml
@@ -1,0 +1,21 @@
+api = "0.4"
+
+[buildpack]
+id = "heroku/clojure"
+version = "0.0.86"
+name = "Clojure"
+
+[[stacks]]
+id = "heroku-18"
+
+[[stacks]]
+id = "heroku-20"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
+
+[metadata]
+shim_v2_tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/clojure-v86.tgz"
+
+[metadata.release.docker]
+repository="public.ecr.aws/r2f9u0w4/heroku-clojure-buildpack"

--- a/shimmed-buildpacks/clojure/package.toml
+++ b/shimmed-buildpacks/clojure/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "."

--- a/shimmed-buildpacks/gradle/CHANGELOG.md
+++ b/shimmed-buildpacks/gradle/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+## main
+
+## 0.0.34
+This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
+for that release can be found here: https://github.com/heroku/heroku-buildpack-gradle/blob/main/CHANGELOG.md#v34

--- a/shimmed-buildpacks/gradle/README.md
+++ b/shimmed-buildpacks/gradle/README.md
@@ -1,0 +1,8 @@
+#  Heroku Cloud Native Gradle Buildpack
+
+Note: This is not a _native_ Cloud Native Buildpack yet. Releases of this buildpack are created by shimming classic
+[Heroku Gradle buildpack](https://github.com/heroku/heroku-buildpack-gradle) releases via
+[cnb-shim](https://github.com/heroku/cnb-shim).
+
+The code in this directory will only turn into a valid buildpack during the release process. To use this buildpack, use
+the release on the official Cloud Native Buildpack registry.

--- a/shimmed-buildpacks/gradle/buildpack.toml
+++ b/shimmed-buildpacks/gradle/buildpack.toml
@@ -14,8 +14,9 @@ id = "heroku-20"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
-shim_v2_tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/gradle-v34.tgz"
+[metadata.shim]
+tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/gradle-v34.tgz"
+sha256="56d9af33cc9ed33c2dd78991278b49063879d61954ed24cb7974aa7e0d43be8d"
 
 [metadata.release.docker]
 repository="public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack"

--- a/shimmed-buildpacks/gradle/buildpack.toml
+++ b/shimmed-buildpacks/gradle/buildpack.toml
@@ -1,0 +1,21 @@
+api = "0.4"
+
+[buildpack]
+id = "heroku/gradle"
+version = "0.0.34"
+name = "Gradle"
+
+[[stacks]]
+id = "heroku-18"
+
+[[stacks]]
+id = "heroku-20"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
+
+[metadata]
+shim_v2_tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/gradle-v34.tgz"
+
+[metadata.release.docker]
+repository="public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack"

--- a/shimmed-buildpacks/gradle/package.toml
+++ b/shimmed-buildpacks/gradle/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "."

--- a/shimmed-buildpacks/scala/CHANGELOG.md
+++ b/shimmed-buildpacks/scala/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+## main
+
+## 0.0.88
+This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
+for that release can be found here: https://github.com/heroku/heroku-buildpack-scala/blob/main/CHANGELOG.md#v88

--- a/shimmed-buildpacks/scala/README.md
+++ b/shimmed-buildpacks/scala/README.md
@@ -1,0 +1,8 @@
+#  Heroku Cloud Native Scala Buildpack
+
+Note: This is not a _native_ Cloud Native Buildpack yet. Releases of this buildpack are created by shimming classic
+[Heroku Scala buildpack](https://github.com/heroku/heroku-buildpack-scala) releases via
+[cnb-shim](https://github.com/heroku/cnb-shim).
+
+The code in this directory will only turn into a valid buildpack during the release process. To use this buildpack, use
+the release on the official Cloud Native Buildpack registry.

--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -14,8 +14,9 @@ id = "heroku-20"
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
-[metadata]
-shim_v2_tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/scala-v88.tgz"
+[metadata.shim]
+tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/scala-v88.tgz"
+sha256="d11afa35769cb336aded3f985eb8efb10cb689c786fc7b3a75253ba6f4fe846e"
 
 [metadata.release.docker]
 repository="public.ecr.aws/r2f9u0w4/heroku-scala-buildpack"

--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -1,0 +1,21 @@
+api = "0.4"
+
+[buildpack]
+id = "heroku/scala"
+version = "0.0.88"
+name = "Scala"
+
+[[stacks]]
+id = "heroku-18"
+
+[[stacks]]
+id = "heroku-20"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
+
+[metadata]
+shim_v2_tarball="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/scala-v88.tgz"
+
+[metadata.release.docker]
+repository="public.ecr.aws/r2f9u0w4/heroku-scala-buildpack"

--- a/shimmed-buildpacks/scala/package.toml
+++ b/shimmed-buildpacks/scala/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "."


### PR DESCRIPTION
Adds support for shimmed V2 buildpacks. The main motivator behind this is that we ideally want to keep track of all JVM CNBs in one place. Since we won't have native CNBs for Scala/Clojure soon, we need a way to track shimmed releases somewhere.

Each shimmed CNB has its own directory containing:
- A `README.md` explaining that this buildpack is shimmed
- A `CHANGELOG.md` which entries point to the V2 CHANGELOG
- A `buildpack.toml` with special metadata that references a specific V2 buildpack release tarball. As normal, it also contains a CNB version number. Since this file is checked in, we can track CNB releases of shimmed buildpacks and have a way to control their CNB version numbers.
- A `package.toml`

By itself, this directory is not a valid CNB. However, during the regular release process (introduced in #9) they will be turned into a CNB with by using [cnb-shim](https://github.com/heroku/cnb-shim). After this, the release process continues as normal. This allows us to treat shimmed CNBs as close to native CNBs as possible. 