### PR TITLE
Fix release workflow

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -17,8 +17,8 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 		cnb_shim_tarball_sha256="109cfc01953cb04e69c82eec1c45c7c800bd57d2fd0eef030c37d8fc37a1cb4d"
 		local_cnb_shim_tarball=$(mktemp)
 
-		v2_buildpack_tarball_url="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.shim.tarball)"
-		v2_buildpack_tarball_sha256="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.shim.sha256)"
+		v2_buildpack_tarball_url="$(yj -t <"${buildpack_toml_path}" | jq -r ".metadata.shim.tarball // empty")"
+		v2_buildpack_tarball_sha256="$(yj -t <"${buildpack_toml_path}" | jq -r ".metadata.shim.sha256 // empty")"
 		local_v2_buildpack_tarball=$(mktemp)
 
 		# If the buildpack has a V2 buildpack tarball in its metadata it's supposed to be a shimmed buildpack.


### PR DESCRIPTION
#11 broke the release workflow for non-shimmed buildpacks by accident.

`jq` with  `-r` will output `null` for values that couldn't be found. The script later checks for an empty string which, of course, will never fail and trigger the shim release path. By using `jq`'s alternative operator `//`, `null` values will now default to an empty string where it matters.