### PR TITLE
Add automated post-release PRs workflow

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -46,6 +46,10 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 		image_name="${buildpack_docker_repository}:${buildpack_version}"
 		pack package-buildpack --config "${buildpack_path}/package.toml" --publish "${image_name}"
 
+		# We might have local changes after shimming the buildpack. To ensure scripts down the pipeline work with
+		# a clean state, we reset all local changes here.
+		git reset --hard
+
 		echo "::set-output name=id::${buildpack_id}"
 		echo "::set-output name=version::${buildpack_version}"
 		echo "::set-output name=path::${buildpack_path}"

--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -49,6 +49,7 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 		# We might have local changes after shimming the buildpack. To ensure scripts down the pipeline work with
 		# a clean state, we reset all local changes here.
 		git reset --hard
+		git clean -fdx
 
 		echo "::set-output name=id::${buildpack_id}"
 		echo "::set-output name=version::${buildpack_version}"

--- a/.github/scripts/release-workflow-prepare-pr.sh
+++ b/.github/scripts/release-workflow-prepare-pr.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+released_buildpack_id="${1:?}"
+released_buildpack_version="${2:?}"
+
+released_buildpack_next_version=$(
+	echo "${released_buildpack_version}" | awk -F. -v OFS=. '{ $NF=sprintf("%d\n", ($NF+1)); printf $0 }'
+)
+
+function escape_for_sed() {
+	echo "${1:?}" | sed 's/[]\/\[\.]/\\&/g'
+}
+
+function is_meta_buildpack_with_dependency() {
+	local -r buildpack_toml_path="${1:?}"
+	local -r buildpack_id="${2:?}"
+
+	yj -t <"${buildpack_toml_path}" | jq -e "[.order[]?.group[]?.id | select(. == \"${buildpack_id}\")] | length > 0" >/dev/null
+}
+
+# This is the heading we're looking for when updating CHANGELOG.md files
+unreleased_heading=$(escape_for_sed "## [Unreleased]")
+
+while IFS="" read -r -d "" buildpack_toml_path; do
+	buildpack_id="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.id)"
+	buildpack_changelog_path="$(dirname "${buildpack_toml_path}")/CHANGELOG.md"
+
+	jq_filter="."
+
+	# Update the released buildpack itself
+	if [[ "${buildpack_id}" == "${released_buildpack_id}" ]]; then
+		if [[ -f "${buildpack_changelog_path}" ]]; then
+			new_version_heading=$(escape_for_sed "## [${released_buildpack_version}] $(date +%Y/%m/%d)")
+			sed -i "s/${unreleased_heading}/${unreleased_heading}\n\n${new_version_heading}/" "${buildpack_changelog_path}"
+		fi
+
+		jq_filter=".buildpack.version = \"${released_buildpack_next_version}\""
+
+	# Update meta-buildpacks that have the released buildpack as a dependency
+	elif is_meta_buildpack_with_dependency "${buildpack_toml_path}" "${released_buildpack_id}"; then
+		if [[ -f "${buildpack_changelog_path}" ]]; then
+			upgrade_entry=$(
+				escape_for_sed "* Upgraded \`${released_buildpack_id}\` to \`${released_buildpack_next_version}\`"
+			)
+
+			sed -i "s/${unreleased_heading}/${unreleased_heading}\n${upgrade_entry}/" "${buildpack_changelog_path}"
+		fi
+
+		jq_filter=$(
+			cat <<-EOF
+				.order |= map(.group |= map(
+					if .id == "${released_buildpack_id}" then
+						.version |= "${released_buildpack_next_version}"
+					else
+						.
+					end
+				))
+			EOF
+		)
+	fi
+
+	# Write the filtered buildpack.toml to disk...
+	updated=$(yj -t <"${buildpack_toml_path}" | jq "${jq_filter}" | yj -jt)
+	echo "${updated}" >"${buildpack_toml_path}"
+
+done < <(find . -name buildpack.toml -print0)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,17 @@ jobs:
             Find the changelog here: [CHANGELOG](${{ steps.package.outputs.path }}/CHANGELOG.md)
           draft: false
           prerelease: false
+      - id: prepare-pr
+        name: "Prepare PR with version bumps and CHANGELOG updates"
+        run: ./.github/scripts/release-workflow-prepare-pr.sh "${{ steps.package.outputs.id }}" "${{ steps.package.outputs.version }}"
+        shell: bash
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: "Post-release updates: ${{ steps.package.outputs.id }} ${{ steps.package.outputs.version }}"
+          commit-message: "Post-release updates: ${{ steps.package.outputs.id }} ${{ steps.package.outputs.version }}"
+          branch-suffix: "random"
+          labels: "automation"
+          body: |
+            Automated pull-request to update buildpack versions and changelogs
+            after releasing version `${{ steps.package.outputs.version }}` of `${{ steps.package.outputs.id }}`.

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
-## main
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0
+## [Unreleased]
+### Added
+* Automated post-release PRs
+
+## [0.1.0]
 * Initial release

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/jvm"
-version = "0.1.0"
+version = "0.1.1"
 name = "JVM"
 
 [[stacks]]

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -1,15 +1,25 @@
 # Changelog
-## main
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0
+## [Unreleased]
+### Added
+* Automated post-release PRs
+
+## [0.2.0]
+### Added
+* Debug logging, can be enabled by setting `HEROKU_BUILDPACK_DEBUG` environment variable
+
+### Changed
 * Code refactoring
 * Logging style now adheres to Heroku's CNB logging style
 * Maven options that are implementation details are no longer logged by default
 * Maven options that are required for proper operation of this buildpack can no longer be overridden by
   `MAVEN_CUSTOM_OPTS` or `MAVEN_CUSTOM_GOALS`
-* Added debug logging, can be enabled by setting `HEROKU_BUILDPACK_DEBUG` environment variable
-* Caching of Maven dependencies has been fixed
-* Fixed exit code of `bin/detect` when detection failed without an error
 
-## 0.1.1
+### Fixed
+* Caching of Maven dependencies
+* Exit code of `bin/detect` when detection failed without an error
+
+## [0.1.0]
 * Initial release

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/maven"
-version = "0.2.0"
+version = "0.2.1"
 name = "Maven"
 clear-env = true
 

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
-## main
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.2
+## [Unreleased]
+### Added
+* Automated post-release PRs
+
+## [0.1.2]
+### Changes
 * Upgrade `heroku/maven` to `0.2.0`
 
-## 0.1.1
+## [0.1.1]
 * Initial release

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -2,17 +2,17 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/java"
-version = "0.1.2"
+version = "0.1.3"
 name = "Java"
 
 [[order]]
 [[order.group]]
 id = "heroku/jvm"
-version = "0.1.0"
+version = "0.1.1"
 
 [[order.group]]
 id = "heroku/maven"
-version = "0.2.0"
+version = "0.2.1"
 
 [[order.group]]
 id = "heroku/procfile"

--- a/shimmed-buildpacks/clojure/CHANGELOG.md
+++ b/shimmed-buildpacks/clojure/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
-## main
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.86
+## [Unreleased]
+
+## [0.0.86]
 This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
 for that release can be found here: https://github.com/heroku/heroku-buildpack-clojure/blob/main/CHANGELOG.md#v86

--- a/shimmed-buildpacks/gradle/CHANGELOG.md
+++ b/shimmed-buildpacks/gradle/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
-## main
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.34
+## [Unreleased]
+
+## [0.0.34]
 This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
 for that release can be found here: https://github.com/heroku/heroku-buildpack-gradle/blob/main/CHANGELOG.md#v34

--- a/shimmed-buildpacks/scala/CHANGELOG.md
+++ b/shimmed-buildpacks/scala/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
-## main
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.88
+## [Unreleased]
+
+## [0.0.88]
 This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
 for that release can be found here: https://github.com/heroku/heroku-buildpack-scala/blob/main/CHANGELOG.md#v88


### PR DESCRIPTION
Enhances the release workflow to automatically open a PR after a release that:
1. Bumps the version number of the released buildpack
2. Move items from `Unreleased` to the released version number in `CHANGELOG.md` for the released buildpack
3. Updates meta-buildpacks that use the released buildpack to use the next unreleased version
4. Update meta-buildpacks `CHANGELOG.md` to include the version bump of its dependencies

Also updates all CHANGELOGs to adhere to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 