### PR TITLE
Java Function Invoker 0.2.0

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -3,6 +3,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Function runtime binary URL no longer has to be specified with the `JVM_INVOKER_JAR_URL` environment variable.
+* Functions are now detected during build. This means the build will now fail if more or less than one valid
+  Salesforce Java function is detected in the project.
+
+### Added
+* The Java function runtime binary integrity is now checked after download
+* Java function runtime is now cached between builds
 
 ## [0.1.0] 2021/01/21
 ### Added

--- a/buildpacks/jvm-function-invoker/bin/build
+++ b/buildpacks/jvm-function-invoker/bin/build
@@ -19,37 +19,126 @@ source "${CNB_BUILDPACK_DIR}/common-lib/jvm_buildpack_utils.sh"
 # Export environment variables
 ########################################################################################################################
 export_env_vars=()
-export_env_vars+=("JVM_INVOKER_JAR_URL")
 export_env_vars+=("HEROKU_BUILDPACK_DEBUG")
 
 bputils::export_env "${platform_dir}" "${export_env_vars[@]}"
 
 ########################################################################################################################
-# Download Invoker
+# Install Java function runtime
 ########################################################################################################################
-log::cnb::header "Installing JVM function invoker"
-log::cnb::debug "Preparing JVM invoker layer"
-invoker_layer_dir="${layers_dir}/jvm-invoker"
-invoker_layer_toml="${invoker_layer_dir}.toml"
-mkdir -p "${invoker_layer_dir}"
+log::cnb::header "Installing Java function runtime"
 
-cat >"${invoker_layer_toml}" <<-EOF
+runtime_jar_url="$(yj -t <"${CNB_BUILDPACK_DIR}/buildpack.toml" | jq -r ".metadata.runtime.url")"
+runtime_jar_sha256="$(yj -t <"${CNB_BUILDPACK_DIR}/buildpack.toml" | jq -r ".metadata.runtime.sha256")"
+
+runtime_layer_dir="${layers_dir}/sf-fx-runtime-java"
+runtime_layer_jar_path="${runtime_layer_dir}/runtime.jar"
+runtime_layer_toml="${runtime_layer_dir}.toml"
+
+cached_layer_runtime_jar_sha256=""
+if [[ -f "${runtime_layer_toml}" ]]; then
+	cached_layer_runtime_jar_sha256=$(yj -t <"${runtime_layer_toml}" | jq -r ".metadata.runtime_jar_sha256 // empty")
+fi
+
+if [[ "${cached_layer_runtime_jar_sha256}" == "${runtime_jar_sha256}" && -f "${runtime_layer_jar_path}" ]]; then
+	log::cnb::info "Installed Java function runtime from cache"
+else
+	log::cnb::debug "Creating function runtime layer"
+	runtime_layer_dir="${layers_dir}/sf-fx-runtime-java"
+	runtime_layer_toml="${runtime_layer_dir}.toml"
+	mkdir -p "${runtime_layer_dir}"
+
+	cat >"${runtime_layer_toml}" <<-EOF
+		launch = true
+		build = false
+		cache = true
+
+		[metadata]
+		runtime_jar_url = "${runtime_jar_url}"
+		runtime_jar_sha256 = "${runtime_jar_sha256}"
+	EOF
+	log::cnb::debug "Function runtime layer successfully created"
+
+	log::cnb::info "Starting download of function runtime"
+	if ! bputils::download_file "${runtime_jar_url}" "${runtime_layer_jar_path}"; then
+		log::cnb::error "Download of function runtime failed" <<-EOF
+			We couldn't download the function runtime at "${runtime_jar_url}".
+			This is usually caused by intermittent network issues. Please try again and contact us should the error persist.
+		EOF
+		exit 1
+	fi
+	log::cnb::info "Function runtime download successful"
+
+	if ! bputils::check_sha256 "${runtime_layer_jar_path}" "${runtime_jar_sha256}"; then
+		log::cnb::error "Function runtime integrity check failed" <<-EOF
+			We could not verify the integrity of the downloaded function runtime.
+			Please try again and contact us should the error persist.
+		EOF
+		exit 1
+	fi
+
+	log::cnb::info "Function runtime installation successful"
+fi
+
+########################################################################################################################
+# Bundle function
+########################################################################################################################
+log::cnb::header "Detecting function"
+
+function_bundle_layer_dir="${layers_dir}/function-bundle"
+function_bundle_toml="${function_bundle_layer_dir}.toml"
+mkdir -p "${function_bundle_layer_dir}"
+
+cat >"${function_bundle_toml}" <<-EOF
 	launch = true
-	build = true
+	build = false
 	cache = false
 EOF
 
-path_to_invoker_jar="${invoker_layer_dir}/invoker.jar"
-log::cnb::info "Downloading invoker JAR file: ${JVM_INVOKER_JAR_URL}"
-if ! bputils::download_file "${JVM_INVOKER_JAR_URL:-}" "${path_to_invoker_jar}"; then
-	log::cnb::error "Download of invoker JAR file failed" <<-EOF
-		You have set JVM_INVOKER_JAR_URL to "${JVM_INVOKER_JAR_URL}". We tried to download the file at this
-		URL, but the download failed. Please verify that the given URL is correct and try again.
+{
+	java -jar "${runtime_layer_jar_path}" bundle "${app_dir}" "${function_bundle_layer_dir}"
+	bundle_exit_code="${?}"
+} || true
+
+case "${bundle_exit_code}" in
+0) log::cnb::info "Detection successful" ;;
+1)
+	log::cnb::error "No functions found" <<-EOF
+		Your project does not seem to contain any Java functions.
+		The output above might contain information about issues with your function.
 	EOF
 	exit 1
-fi
+	;;
+2)
+	log::cnb::error "Multiple functions found" <<-EOF
+		Your project contains multiple Java functions.
+		Currently, only projects that contain exactly one (1) function are supported.
+	EOF
+	exit 1
+	;;
+3 | 4 | 5 | 6)
+	log::cnb::error "Detection failed" <<-EOF
+		Function detection failed with internal error "${bundle_exit_code}".
+	EOF
+	exit 1
+	;;
 
-log::cnb::info "Invoker installation successful!"
+*)
+	log::cnb::error "Detection failed" <<-EOF
+		Function detection failed with unexpected error code ${bundle_exit_code}.
+		The output above might contain hints what caused this error to happen.
+	EOF
+	exit 1
+	;;
+esac
+
+########################################################################################################################
+# Log function info
+########################################################################################################################
+bundle_toml="${function_bundle_layer_dir}/function-bundle.toml"
+log::cnb::header "Detected function: $(yj -t <"${bundle_toml}" | jq -r ".function.class")"
+log::cnb::info "Payload type: $(log::cnb::bold "$(yj -t <"${bundle_toml}" | jq -r ".function.payload_class")")"
+log::cnb::info "Return type: $(log::cnb::bold "$(yj -t <"${bundle_toml}" | jq -r ".function.return_class")")"
 
 ########################################################################################################################
 # Generate launch.toml
@@ -57,5 +146,5 @@ log::cnb::info "Invoker installation successful!"
 cat >>"${layers_dir}/launch.toml" <<-EOF
 	[[processes]]
 	type = "web"
-	command = "java -jar ${path_to_invoker_jar} ${app_dir}"
+	command = "java -jar ${runtime_layer_jar_path} serve ${function_bundle_layer_dir}"
 EOF

--- a/buildpacks/jvm-function-invoker/bin/detect
+++ b/buildpacks/jvm-function-invoker/bin/detect
@@ -7,13 +7,6 @@ platform_dir="${1:?}"
 # shellcheck disable=SC2034
 build_plan="${2:?}"
 
-# We currently require an env var that points to a download URL for the invoker.
-# When the invoker is finally released, this requirement can be removed and this buildpack
-# will use the latest available version, recorded in the buildpack itself.
-if [[ ! -f "${platform_dir}/env/JVM_INVOKER_JAR_URL" ]]; then
-	exit 100
-fi
-
 cat >"${build_plan}" <<-EOF
 	[[requires]]
 	name = "jdk"

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/jvm-function-invoker"
-version = "0.1.1"
+version = "0.2.0"
 name = "JVM Function Invoker"
 clear-env = true
 
@@ -16,6 +16,9 @@ id = "heroku-20"
 id = "io.buildpacks.stacks.bionic"
 
 [metadata]
+[metadata.runtime]
+url = "https://sf-fx-java-internal-early-access.s3.amazonaws.com/sf-fx-runtime-java-1.0-SNAPSHOT-jar-with-dependencies.jar"
+sha256 = "c36be4ca15331c7b87355988171adec852a4aa4b41a91a1fb34fbd6e1c8fca01"
 
 [metadata.release]
 

--- a/common/lib/jvm_buildpack_utils.sh
+++ b/common/lib/jvm_buildpack_utils.sh
@@ -37,6 +37,13 @@ bputils::download_file() {
 	curl --retry 3 --silent --fail --max-time 10 --location "${url}" --output "${target_path}"
 }
 
+bputils::check_sha256() {
+	local -r path="${1:?}"
+	local -r expected_sha256="${2:?}"
+
+	echo "${expected_sha256} ${path}" | sha256sum --check --status
+}
+
 bputils::export_env() {
 	local -r platform_dir="${1:?}"
 	local -r env_vars=("${@:2}")

--- a/common/lib/log/cnb.sh
+++ b/common/lib/log/cnb.sh
@@ -28,3 +28,8 @@ log::cnb::debug() {
 log::cnb::info() {
 	echo "[INFO] $*"
 }
+
+log::cnb::bold() {
+	local -r string="${1:?}"
+	echo -e "\033[1m${string}\033[0m"
+}

--- a/common/meta-build.sh
+++ b/common/meta-build.sh
@@ -10,6 +10,10 @@ buildpack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 target_dir_name="target"
 target_dir="${buildpack_dir}/${target_dir_name}"
 
+if [[ -d "${target_dir}" ]]; then
+	rm -r "${target_dir}"
+fi
+
 mkdir "${target_dir}"
 rsync -a -L "${buildpack_dir}/" "${target_dir}" --exclude "${target_dir_name}"
 

--- a/common/rsync-build.sh
+++ b/common/rsync-build.sh
@@ -8,5 +8,9 @@ buildpack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 target_dir_name="target"
 target_dir="${buildpack_dir}/${target_dir_name}"
 
+if [[ -d "${target_dir}" ]]; then
+	rm -r "${target_dir}"
+fi
+
 mkdir "${target_dir}"
 rsync -a -L "${buildpack_dir}/" "${target_dir}" --exclude "${target_dir_name}"

--- a/common/shim-build.sh
+++ b/common/shim-build.sh
@@ -6,6 +6,10 @@ buildpack_toml_path="${buildpack_dir}/buildpack.toml"
 target_dir_name="target"
 target_dir="${buildpack_dir}/${target_dir_name}"
 
+if [[ -d "${target_dir}" ]]; then
+	rm -r "${target_dir}"
+fi
+
 cnb_shim_tarball_url="https://github.com/heroku/cnb-shim/releases/download/v0.3/cnb-shim-v0.3.tgz"
 cnb_shim_tarball_sha256="109cfc01953cb04e69c82eec1c45c7c800bd57d2fd0eef030c37d8fc37a1cb4d"
 local_cnb_shim_tarball=$(mktemp)

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -4,7 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 * Upgraded `heroku/jvm` to `0.1.3`
-* Upgraded `heroku/jvm-function-invoker` to `0.1.1`
+* Upgraded `heroku/jvm-function-invoker` to `0.2.0`
 
 ## [0.1.0] 2021/01/21
 ### Added

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/java-function"
-version = "0.1.1"
+version = "0.2.0"
 name = "Java Function"
 
 [[order]]
@@ -17,7 +17,7 @@ version = "0.2.1"
 
 [[order.group]]
 id = "heroku/jvm-function-invoker"
-version = "0.1.1"
+version = "0.2.0"
 
 [metadata]
 


### PR DESCRIPTION
From the changelog:
### Changed
* Function runtime binary URL no longer has to be specified with the `JVM_INVOKER_JAR_URL` environment variable.
* Functions are now detected during build. This means the build will now fail if more or less than one valid
  Salesforce Java function is detected in the project.

### Added
* The Java function runtime binary integrity is now checked after download
* Java function runtime is now cached between builds
