### PR TITLE
jvm-function-invoker 0.2.1

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -3,6 +3,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Now requires (in the CNB sense) `jvm-application` to pass detection.
+* Will now fail detection if there is no `function.toml` present.
+
+### Removed
+* The Java function runtime binary integrity is now checked after download (temporarily removed).
+* Java function runtime is now cached between builds (temporarily removed).
 
 ## [0.2.0] 2021/02/01
 ### Changed
@@ -11,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Salesforce Java function is detected in the project.
 
 ### Added
-* The Java function runtime binary integrity is now checked after download
-* Java function runtime is now cached between builds
+* The Java function runtime binary integrity is now checked after download.
+* Java function runtime is now cached between builds.
 
 ## [0.1.0] 2021/01/21
 ### Added
-* Initial release
+* Initial release.

--- a/buildpacks/jvm-function-invoker/bin/build
+++ b/buildpacks/jvm-function-invoker/bin/build
@@ -55,7 +55,9 @@ else
 
 		[metadata]
 		runtime_jar_url = "${runtime_jar_url}"
-		runtime_jar_sha256 = "${runtime_jar_sha256}"
+
+		# See commented code below on why this is currently not used
+		# runtime_jar_sha256 = "${runtime_jar_sha256}"
 	EOF
 	log::cnb::debug "Function runtime layer successfully created"
 
@@ -69,13 +71,16 @@ else
 	fi
 	log::cnb::info "Function runtime download successful"
 
-	if ! bputils::check_sha256 "${runtime_layer_jar_path}" "${runtime_jar_sha256}"; then
-		log::cnb::error "Function runtime integrity check failed" <<-EOF
-			We could not verify the integrity of the downloaded function runtime.
-			Please try again and contact us should the error persist.
-		EOF
-		exit 1
-	fi
+	# SHA256 checksum checking is disabled for as the function runtime is very unstable and is updated very often.
+	# We don't want to trigger a whole release cycle just for a minor update. This code must be reactivated for beta/GA!
+
+	#if ! bputils::check_sha256 "${runtime_layer_jar_path}" "${runtime_jar_sha256}"; then
+	#	log::cnb::error "Function runtime integrity check failed" <<-EOF
+	#		We could not verify the integrity of the downloaded function runtime.
+	#		Please try again and contact us should the error persist.
+	#	EOF
+	#	exit 1
+	#fi
 
 	log::cnb::info "Function runtime installation successful"
 fi

--- a/buildpacks/jvm-function-invoker/bin/detect
+++ b/buildpacks/jvm-function-invoker/bin/detect
@@ -7,9 +7,18 @@ platform_dir="${1:?}"
 # shellcheck disable=SC2034
 build_plan="${2:?}"
 
-cat >"${build_plan}" <<-EOF
-	[[requires]]
-	name = "jdk"
-EOF
+# We check for a function.toml to be able to distinguish between regular JVM applications and a function.
+# Just from the application alone, they're indistinguishable by design.
+if [[ -f "${app_dir}/function.toml" ]]; then
+	cat >"${build_plan}" <<-EOF
+		[[requires]]
+		name = "jdk"
 
-exit 0
+		[[requires]]
+		name = "jvm-application"
+	EOF
+
+	exit 0
+fi
+
+exit 100

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Automated post-release PRs
+* Now requires (in the CNB sense) `jdk` to pass detection
+* Now provides (in the CNB sense) `jvm-application` to subsequent buildpacks
 
 ## [0.2.0]
 ### Added

--- a/buildpacks/maven/bin/detect
+++ b/buildpacks/maven/bin/detect
@@ -11,6 +11,13 @@ extensions=(xml atom clj groovy rb scala yaml yml)
 
 for extension in "${extensions[@]}"; do
 	if [[ -f "pom.${extension}" ]]; then
+		cat >"${build_plan}" <<-EOF
+			[[requires]]
+			name = "jdk"
+
+			[[provides]]
+			name = "jvm-application"
+		EOF
 		exit 0
 	fi
 done

--- a/buildpacks/maven/bin/detect
+++ b/buildpacks/maven/bin/detect
@@ -15,6 +15,9 @@ for extension in "${extensions[@]}"; do
 			[[requires]]
 			name = "jdk"
 
+			[[requires]]
+			name = "jvm-application"
+
 			[[provides]]
 			name = "jvm-application"
 		EOF


### PR DESCRIPTION
Removes the checksum verification for invoker/runtime downloads. The runtime is not yet stable and there will be many updates in s short period of time. To ease testing those changes, the checksum check had to go. It will be re-enabled as soon as the runtime spec settled.

Also introduces a new `[requires]`/`[provides]` pair: `jvm-application`. The Maven buildpack will provide (and require) it. Downstream buildpacks can use this to require a built JVM application - regardless of the build tooling used. This was a requirement for the function invoker buildpack.