### PR TITLE
Make meta buildpacks reference released version images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,8 @@ workflows:
                 - "shimmed-buildpacks/scala"
                 - "shimmed-buildpacks/gradle"
                 - "shimmed-buildpacks/clojure"
+                - "test/meta-buildpacks/java"
+                - "test/meta-buildpacks/java-function"
       - rapier:
           matrix:
             parameters:

--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -11,21 +11,21 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 	buildpack_version="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.version)"
 	buildpack_docker_repository="$(yj -t <"${buildpack_toml_path}" | jq -r .metadata.release.docker.repository)"
 	buildpack_path=$(dirname "${buildpack_toml_path}")
+	buildpack_build_path="${buildpack_path}"
 
 	if [[ $buildpack_id == "${REQUESTED_BUILDPACK_ID}" ]]; then
 		# Some buildpacks require a build step before packaging. If we detect a build.sh script, we execute it and
-		# modify some variables to point to the directory with the built buildpack instead.
+		# modify the buildpack_build_path variable to point to the directory with the built buildpack instead.
 		if [[ -f "${buildpack_path}/build.sh" ]]; then
 			echo "Buildpack has build script, executing..."
 			"${buildpack_path}/build.sh"
 			echo "Build finished!"
 
-			buildpack_path="${buildpack_path}/target"
-			buildpack_toml_path="${buildpack_path}/buildpack.toml"
+			buildpack_build_path="${buildpack_path}/target"
 		fi
 
 		image_name="${buildpack_docker_repository}:${buildpack_version}"
-		pack package-buildpack --config "${buildpack_path}/package.toml" --publish "${image_name}"
+		pack package-buildpack --config "${buildpack_build_path}/package.toml" --publish "${image_name}"
 
 		# We might have local changes after building and/or shimming the buildpack. To ensure scripts down the pipeline
 		# work with a clean state, we reset all local changes here.
@@ -35,7 +35,7 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 		echo "::set-output name=id::${buildpack_id}"
 		echo "::set-output name=version::${buildpack_version}"
 		echo "::set-output name=path::${buildpack_path}"
-		echo "::set-output name=address::${buildpack_docker_repository}@$(crane digest "${image_name}")"
+		echo "::set-output name=address::docker://${image_name}"
 		exit 0
 	fi
 done < <(find . -name buildpack.toml -print0)

--- a/.github/scripts/release-workflow-prepare-pr.sh
+++ b/.github/scripts/release-workflow-prepare-pr.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 released_buildpack_id="${1:?}"
 released_buildpack_version="${2:?}"
+released_buildpack_image_address="${3:?}"
 
 released_buildpack_next_version=$(
 	echo "${released_buildpack_version}" | awk -F. -v OFS=. '{ $NF=sprintf("%d\n", ($NF+1)); printf $0 }'
@@ -19,12 +20,21 @@ function is_meta_buildpack_with_dependency() {
 	yj -t <"${buildpack_toml_path}" | jq -e "[.order[]?.group[]?.id | select(. == \"${buildpack_id}\")] | length > 0" >/dev/null
 }
 
+function package_toml_contains_image_address_root() {
+	local -r package_toml_path="${1:?}"
+	local -r image_address_root="${2:?}"
+
+	yj -t <"${package_toml_path}" | jq -e "[.dependencies[].uri | select(startswith(\"${image_address_root}\"))] | length > 0" >/dev/null
+}
+
 # This is the heading we're looking for when updating CHANGELOG.md files
 unreleased_heading=$(escape_for_sed "## [Unreleased]")
 
 while IFS="" read -r -d "" buildpack_toml_path; do
 	buildpack_id="$(yj -t <"${buildpack_toml_path}" | jq -r .buildpack.id)"
-	buildpack_changelog_path="$(dirname "${buildpack_toml_path}")/CHANGELOG.md"
+	buildpack_path="$(dirname "${buildpack_toml_path}")"
+	buildpack_package_toml_path="${buildpack_path}/package.toml"
+	buildpack_changelog_path="${buildpack_path}/CHANGELOG.md"
 
 	jq_filter="."
 
@@ -39,9 +49,26 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 
 	# Update meta-buildpacks that have the released buildpack as a dependency
 	elif is_meta_buildpack_with_dependency "${buildpack_toml_path}" "${released_buildpack_id}"; then
+		# There are two cases of meta-buildpacks that reference the released buildpack:
+		#
+		# 1. The released buildpack is referenced by a local path. In this case, we need to update the reference to
+		#    the next version, not the released version.
+		# 2. The released buildpack is referenced by a Docker address. In this case, we need to update the reference
+		#    to the released version instead.
+		target_version_for_meta_buildpack="${released_buildpack_next_version}"
+
+		released_buildpack_image_address_root="${released_buildpack_image_address%:*}"
+		if package_toml_contains_image_address_root "${buildpack_package_toml_path}" "${released_buildpack_image_address_root}"; then
+			target_version_for_meta_buildpack="${released_buildpack_version}"
+
+			package_toml_filter=".dependencies[].uri |= if startswith(\"${released_buildpack_image_address_root}\") then \"${released_buildpack_image_address}\" else . end"
+			updated_package_toml=$(yj -t <"${buildpack_package_toml_path}" | jq "${package_toml_filter}" | yj -jt)
+			echo "${updated_package_toml}" >"${buildpack_package_toml_path}"
+		fi
+
 		if [[ -f "${buildpack_changelog_path}" ]]; then
 			upgrade_entry=$(
-				escape_for_sed "* Upgraded \`${released_buildpack_id}\` to \`${released_buildpack_next_version}\`"
+				escape_for_sed "* Upgraded \`${released_buildpack_id}\` to \`${target_version_for_meta_buildpack}\`"
 			)
 
 			sed -i "s/${unreleased_heading}/${unreleased_heading}\n${upgrade_entry}/" "${buildpack_changelog_path}"
@@ -51,7 +78,7 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 			cat <<-EOF
 				.order |= map(.group |= map(
 					if .id == "${released_buildpack_id}" then
-						.version |= "${released_buildpack_next_version}"
+						.version |= "${target_version_for_meta_buildpack}"
 					else
 						.
 					end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,12 @@ jobs:
           release_name: ${{ steps.package.outputs.id }} ${{ steps.package.outputs.version }}
           body: |
             Find the changelog here: [CHANGELOG](${{ steps.package.outputs.path }}/CHANGELOG.md)
+            Docker: ${{ steps.package.outputs.address }}
           draft: false
           prerelease: false
       - id: prepare-pr
         name: "Prepare PR with version bumps and CHANGELOG updates"
-        run: ./.github/scripts/release-workflow-prepare-pr.sh "${{ steps.package.outputs.id }}" "${{ steps.package.outputs.version }}"
+        run: ./.github/scripts/release-workflow-prepare-pr.sh "${{ steps.package.outputs.id }}" "${{ steps.package.outputs.version }}" "${{ steps.package.outputs.address }}"
         shell: bash
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -3,11 +3,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+* Now packages released buildpack images instead of local paths to ensure standalone and bundled
+  versions are exactly the same.
 
 ## [0.2.1] 2021/02/02
 * Upgraded `heroku/jvm-function-invoker` to `0.2.1`
 
 ## [0.2.0] 2021/02/01
+## Changed
 * Upgraded `heroku/jvm` to `0.1.3`
 * Upgraded `heroku/jvm-function-invoker` to `0.2.0`
 

--- a/meta-buildpacks/java-function/build.sh
+++ b/meta-buildpacks/java-function/build.sh
@@ -1,1 +1,0 @@
-../../common/meta-build.sh

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -2,22 +2,22 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/java-function"
-version = "0.2.2"
+version = "0.3.0"
 name = "Java Function"
 
 [[order]]
 
 [[order.group]]
 id = "heroku/jvm"
-version = "0.1.3"
+version = "0.1.2"
 
 [[order.group]]
 id = "heroku/maven"
-version = "0.2.1"
+version = "0.2.0"
 
 [[order.group]]
 id = "heroku/jvm-function-invoker"
-version = "0.2.1"
+version = "0.2.0"
 
 [metadata]
 

--- a/meta-buildpacks/java-function/package.toml
+++ b/meta-buildpacks/java-function/package.toml
@@ -2,10 +2,10 @@
 uri = "."
 
 [[dependencies]]
-uri = "../../buildpacks/jvm"
+uri = "public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack:0.1.2"
 
 [[dependencies]]
-uri = "../../buildpacks/maven"
+uri = "public.ecr.aws/r2f9u0w4/heroku-maven-buildpack:0.2.0"
 
 [[dependencies]]
-uri = "../../buildpacks/jvm-function-invoker"
+uri = "public.ecr.aws/r2f9u0w4/heroku-jvm-function-invoker-buildpack:0.2.0"

--- a/meta-buildpacks/java-function/package.toml
+++ b/meta-buildpacks/java-function/package.toml
@@ -2,10 +2,10 @@
 uri = "."
 
 [[dependencies]]
-uri = "public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack:0.1.2"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack:0.1.2"
 
 [[dependencies]]
-uri = "public.ecr.aws/r2f9u0w4/heroku-maven-buildpack:0.2.0"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack:0.2.0"
 
 [[dependencies]]
-uri = "public.ecr.aws/r2f9u0w4/heroku-jvm-function-invoker-buildpack:0.2.0"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-function-invoker-buildpack:0.2.0"

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -3,10 +3,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+* Now packages released buildpack images instead of local paths to ensure standalone and bundled
+  versions are exactly the same.
 
 ## [0.1.3] 2021/01/22
 * Upgraded `heroku/jvm` to `0.1.3`
-* Upgraded `heroku/jvm` to `0.1.2`
+
 ### Added
 * Automated post-release PRs
 

--- a/meta-buildpacks/java/build.sh
+++ b/meta-buildpacks/java/build.sh
@@ -1,1 +1,0 @@
-../../common/meta-build.sh

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -2,18 +2,18 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/java"
-version = "0.1.4"
+version = "0.3.0"
 name = "Java"
 
 [[order]]
 
 [[order.group]]
 id = "heroku/jvm"
-version = "0.1.3"
+version = "0.1.2"
 
 [[order.group]]
 id = "heroku/maven"
-version = "0.2.1"
+version = "0.2.0"
 
 [[order.group]]
 id = "heroku/procfile"
@@ -24,7 +24,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/gradle"
-version = "0.4.0"
+version = "0.0.34"
 
 [[order.group]]
 id = "heroku/procfile"

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -2,13 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack:0.1.2"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack:0.1.2"
 
 [[dependencies]]
-uri = "public.ecr.aws/r2f9u0w4/heroku-maven-buildpack:0.2.0"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack:0.2.0"
 
 [[dependencies]]
-uri = "public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack:0.0.34"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack:0.0.34"
 
 [[dependencies]]
 # Should be urn:cnb:registry:heroku/procfile@0.6.1 as soon as pack supports it. (0.16.1?)

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -2,13 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "../../buildpacks/jvm"
+uri = "public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack:0.1.2"
 
 [[dependencies]]
-uri = "../../buildpacks/maven"
+uri = "public.ecr.aws/r2f9u0w4/heroku-maven-buildpack:0.2.0"
 
 [[dependencies]]
-uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.4.0&name=Gradle"
+uri = "public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack:0.0.34"
 
 [[dependencies]]
 # Should be urn:cnb:registry:heroku/procfile@0.6.1 as soon as pack supports it. (0.16.1?)

--- a/test/meta-buildpacks/java-function/build.sh
+++ b/test/meta-buildpacks/java-function/build.sh
@@ -1,0 +1,1 @@
+../../../common/meta-build.sh

--- a/test/meta-buildpacks/java-function/buildpack.toml
+++ b/test/meta-buildpacks/java-function/buildpack.toml
@@ -18,10 +18,3 @@ version = "0.2.1"
 [[order.group]]
 id = "heroku/jvm-function-invoker"
 version = "0.2.1"
-
-[metadata]
-
-[metadata.release]
-
-[metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack"

--- a/test/meta-buildpacks/java-function/buildpack.toml
+++ b/test/meta-buildpacks/java-function/buildpack.toml
@@ -1,0 +1,27 @@
+api = "0.4"
+
+[buildpack]
+id = "heroku/java-function-test"
+version = "0.0.0"
+name = "Java Function"
+
+[[order]]
+
+[[order.group]]
+id = "heroku/jvm"
+version = "0.1.3"
+
+[[order.group]]
+id = "heroku/maven"
+version = "0.2.1"
+
+[[order.group]]
+id = "heroku/jvm-function-invoker"
+version = "0.2.1"
+
+[metadata]
+
+[metadata.release]
+
+[metadata.release.docker]
+repository = "public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack"

--- a/test/meta-buildpacks/java-function/package.toml
+++ b/test/meta-buildpacks/java-function/package.toml
@@ -1,0 +1,11 @@
+[buildpack]
+uri = "."
+
+[[dependencies]]
+uri = "../../../buildpacks/jvm"
+
+[[dependencies]]
+uri = "../../../buildpacks/maven"
+
+[[dependencies]]
+uri = "../../../buildpacks/jvm-function-invoker"

--- a/test/meta-buildpacks/java/build.sh
+++ b/test/meta-buildpacks/java/build.sh
@@ -1,0 +1,1 @@
+../../../common/meta-build.sh

--- a/test/meta-buildpacks/java/buildpack.toml
+++ b/test/meta-buildpacks/java/buildpack.toml
@@ -1,0 +1,39 @@
+api = "0.4"
+
+[buildpack]
+id = "heroku/java-test"
+version = "0.0.0"
+name = "Java"
+
+[[order]]
+
+[[order.group]]
+id = "heroku/jvm"
+version = "0.1.3"
+
+[[order.group]]
+id = "heroku/maven"
+version = "0.2.1"
+
+[[order.group]]
+id = "heroku/procfile"
+version = "0.6.1"
+optional = true
+
+[[order]]
+
+[[order.group]]
+id = "heroku/gradle"
+version = "0.0.34"
+
+[[order.group]]
+id = "heroku/procfile"
+version = "0.6.1"
+optional = true
+
+[metadata]
+
+[metadata.release]
+
+[metadata.release.docker]
+repository = "public.ecr.aws/r2f9u0w4/heroku-java-buildpack"

--- a/test/meta-buildpacks/java/buildpack.toml
+++ b/test/meta-buildpacks/java/buildpack.toml
@@ -30,10 +30,3 @@ version = "0.0.34"
 id = "heroku/procfile"
 version = "0.6.1"
 optional = true
-
-[metadata]
-
-[metadata.release]
-
-[metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-java-buildpack"

--- a/test/meta-buildpacks/java/package.toml
+++ b/test/meta-buildpacks/java/package.toml
@@ -8,9 +8,6 @@ uri = "../../../buildpacks/jvm"
 uri = "../../../buildpacks/maven"
 
 [[dependencies]]
-uri = "../../../buildpacks/jvm-function-invoker"
-
-[[dependencies]]
 uri = "../../../shimmed-buildpacks/gradle"
 
 [[dependencies]]

--- a/test/meta-buildpacks/java/package.toml
+++ b/test/meta-buildpacks/java/package.toml
@@ -1,0 +1,18 @@
+[buildpack]
+uri = "."
+
+[[dependencies]]
+uri = "../../../buildpacks/jvm"
+
+[[dependencies]]
+uri = "../../../buildpacks/maven"
+
+[[dependencies]]
+uri = "../../../buildpacks/jvm-function-invoker"
+
+[[dependencies]]
+uri = "../../../shimmed-buildpacks/gradle"
+
+[[dependencies]]
+# Should be urn:cnb:registry:heroku/procfile@0.6.1 as soon as pack supports it. (0.16.1?)
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:74881b33e1e33eea38b419e667b0a99ac50e536727eeefd1b2eeb7ff3a937ffd"

--- a/test/specs/java/spec_helper.rb
+++ b/test/specs/java/spec_helper.rb
@@ -4,7 +4,7 @@ require "java-properties"
 require_relative "../../rapier/rapier"
 
 def rapier
-  Rapier::Runner.new("test/fixtures", "heroku/buildpacks:18", default_buildpacks: ["./meta-buildpacks/java"])
+  Rapier::Runner.new("test/fixtures", "heroku/buildpacks:18", default_buildpacks: ["./test/meta-buildpacks/java"])
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Meta Buildpacks now reference released Docker images for their dependencies instead of local directory paths. This ensures that meta buildpacks contain the same code as the standalone buildpacks.

For testing, a new set of meta buildpacks have been created to test the combination of all changes in the repository across all buildpacks. These still reference local directory paths.