### PR TITLE
Remove docker:// prefix in release process

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -35,7 +35,7 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 		echo "::set-output name=id::${buildpack_id}"
 		echo "::set-output name=version::${buildpack_version}"
 		echo "::set-output name=path::${buildpack_path}"
-		echo "::set-output name=address::docker://${image_name}"
+		echo "::set-output name=address::${image_name}"
 		exit 0
 	fi
 done < <(find . -name buildpack.toml -print0)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           prerelease: false
       - id: prepare-pr
         name: "Prepare PR with version bumps and CHANGELOG updates"
-        run: ./.github/scripts/release-workflow-prepare-pr.sh "${{ steps.package.outputs.id }}" "${{ steps.package.outputs.version }}" "${{ steps.package.outputs.address }}"
+        run: ./.github/scripts/release-workflow-prepare-pr.sh "${{ steps.package.outputs.id }}" "${{ steps.package.outputs.version }}" "docker://${{ steps.package.outputs.address }}"
         shell: bash
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Addendum to #33 

CNB tooling does not work when image names are prefixed with docker://. This removes the prefix for most of the release process and just adds it to the argument of the PR script.