### PR TITLE
Use Docker image digests in meta buildpacks

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -35,7 +35,7 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 		echo "::set-output name=id::${buildpack_id}"
 		echo "::set-output name=version::${buildpack_version}"
 		echo "::set-output name=path::${buildpack_path}"
-		echo "::set-output name=address::${image_name}"
+		echo "::set-output name=address::${buildpack_docker_repository}@$(crane digest "${image_name}")"
 		exit 0
 	fi
 done < <(find . -name buildpack.toml -print0)

--- a/.github/scripts/release-workflow-prepare-pr.sh
+++ b/.github/scripts/release-workflow-prepare-pr.sh
@@ -57,7 +57,7 @@ while IFS="" read -r -d "" buildpack_toml_path; do
 		#    to the released version instead.
 		target_version_for_meta_buildpack="${released_buildpack_next_version}"
 
-		released_buildpack_image_address_root="${released_buildpack_image_address%:*}"
+		released_buildpack_image_address_root="${released_buildpack_image_address%@*}"
 		if package_toml_contains_image_address_root "${buildpack_package_toml_path}" "${released_buildpack_image_address_root}"; then
 			target_version_for_meta_buildpack="${released_buildpack_version}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           release_name: ${{ steps.package.outputs.id }} ${{ steps.package.outputs.version }}
           body: |
             Find the changelog here: [CHANGELOG](${{ steps.package.outputs.path }}/CHANGELOG.md)
-            Docker: ${{ steps.package.outputs.address }}
+            Docker: `docker pull ${{ steps.package.outputs.address }}`
           draft: false
           prerelease: false
       - id: prepare-pr

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
+### Changed
 * Now packages released buildpack images instead of local paths to ensure standalone and bundled
   versions are exactly the same.
 

--- a/meta-buildpacks/java-function/package.toml
+++ b/meta-buildpacks/java-function/package.toml
@@ -2,10 +2,10 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack:0.1.2"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack@sha256:37483599729c5afbd747a2c8d5965347a32d134e4c5d1b9b5dadfffa81fe5014"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack:0.2.0"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack@sha256:e495f3562e5f1bb0c0ccc9e5b7c319c29ab95e4c2525c124800964981ada27f6"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-function-invoker-buildpack:0.2.0"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-function-invoker-buildpack@sha256:09f7a8663026dac65266ebc3edabe14b59cc7aadfa92f98bb13b33d498c932cf"

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
+### Changed
 * Now packages released buildpack images instead of local paths to ensure standalone and bundled
   versions are exactly the same.
 

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -2,13 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack:0.1.2"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack@sha256:37483599729c5afbd747a2c8d5965347a32d134e4c5d1b9b5dadfffa81fe5014"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack:0.2.0"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack@sha256:e495f3562e5f1bb0c0ccc9e5b7c319c29ab95e4c2525c124800964981ada27f6"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack:0.0.34"
+uri = "docker://public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack@sha256:7163f393470de8255fe03e06d55d3ae7bf59bf683f4ff2651ed92b6538eed0ad"
 
 [[dependencies]]
 # Should be urn:cnb:registry:heroku/procfile@0.6.1 as soon as pack supports it. (0.16.1?)


### PR DESCRIPTION
Another (and hopefully the last) addendum to fix the release process after #33. This changes the image references to use digests. This is more strict and is in-line with what CNB release tooling expects.

See: #34 #33 