### PR TITLE
Java functions fixes

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -3,6 +3,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Support for the `PORT` environment variable at runtime for setting the HTTP port
+
+### Fixed
+* When using an older version of `pack`, the function layer might be incorrectly restored, causing errors
+  "directory not empty" during function detection. A workaround has been added.
 
 ## [0.2.1] 2021/02/03
 ### Changed

--- a/buildpacks/jvm-function-invoker/bin/build
+++ b/buildpacks/jvm-function-invoker/bin/build
@@ -92,6 +92,13 @@ log::cnb::header "Detecting function"
 
 function_bundle_layer_dir="${layers_dir}/function-bundle"
 function_bundle_toml="${function_bundle_layer_dir}.toml"
+
+# Workaround (Feb 2021): Benny 1.0.3 has a bug that restores this layer regardless of the cache setting.
+if [[ -d "${function_bundle_layer_dir}" ]]; then
+	rm -rf "${function_bundle_layer_dir}"
+fi
+# End workaround
+
 mkdir -p "${function_bundle_layer_dir}"
 
 cat >"${function_bundle_toml}" <<-EOF
@@ -151,5 +158,5 @@ log::cnb::info "Return type: $(log::cnb::bold "$(yj -t <"${bundle_toml}" | jq -r
 cat >>"${layers_dir}/launch.toml" <<-EOF
 	[[processes]]
 	type = "web"
-	command = "java -jar ${runtime_layer_jar_path} serve ${function_bundle_layer_dir}"
+	command = "java -jar ${runtime_layer_jar_path} serve ${function_bundle_layer_dir} -p \${PORT:-8080}"
 EOF

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -3,6 +3,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Status headers are now bold
+
+### Fixed
+* `JAVA_HOME` will now be correctly set when using older versions of `pack`
 
 ## [0.1.2] 2021/01/22
 ### Changed

--- a/buildpacks/jvm/bin/build
+++ b/buildpacks/jvm/bin/build
@@ -52,6 +52,10 @@ else
 	install_certs "${jdkLayer}"
 	install_profile "${bpDir}" "${jdkLayer}/profile.d"
 	install_jdk_overlay "${jdkVersion}" "${jdkLayer}" "${appDir}"
+
+	mkdir -p "${jdkLayer}/env.build"
+	echo -n "${jdkLayer}" >"${jdkLayer}/env.build/JAVA_HOME"
+
 	info "JDK ${jdkVersion} installed"
 
 	jreLayerToml="$(bp_layer_metadata_create "true" "false" "false" "${jdkMetadata}")"
@@ -59,5 +63,9 @@ else
 	install_jre "${jdkLayer}" "${jreLayer}"
 	install_certs "${jreLayer}"
 	install_profile "${bpDir}" "${jreLayer}/profile.d"
+
+	mkdir -p "${jreLayer}/env.launch"
+	echo -n "${jreLayer}" >"${jreLayer}/env.launch/JAVA_HOME"
+
 	info "JRE ${jdkVersion} installed"
 fi

--- a/buildpacks/jvm/lib/v3/common.sh
+++ b/buildpacks/jvm/lib/v3/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 status() {
-	local color="\033[0;35m"
+	local color="\033[1;35m"
 	local no_color="\033[0m"
 	echo -e "\n${color}[${1:-""}]${no_color}"
 }


### PR DESCRIPTION
These buildpacks run with a slightly older version of `pack`, causing some incompatibilities. This PR adds workarounds/fixes for those. In addition:

- `heroku/jvm` logging now bolds status lines (now consistent with other buildpacks)
- `heroku/jvm-function-invoker` now supports setting `PORT`