### PR TITLE
Add buildpack metadata

### DIFF
--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -5,6 +5,9 @@ id = "heroku/jvm-function-invoker"
 version = "0.2.3"
 name = "JVM Function Invoker"
 clear-env = true
+homepage = "https://github.com/heroku/buildpacks-jvm"
+keywords = ["java", "function"]
+licenses = ["MIT"]
 
 [[stacks]]
 id = "heroku-18"

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -4,6 +4,10 @@ api = "0.4"
 id = "heroku/jvm"
 version = "0.1.4"
 name = "JVM"
+homepage = "https://github.com/heroku/buildpacks-jvm"
+description = "Official Heroku buildpack for installing a JVM."
+keywords = ["java", "jvm", "jdk", "openjdk"]
+licenses = ["MIT"]
 
 [[stacks]]
 id = "heroku-18"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -5,6 +5,10 @@ id = "heroku/maven"
 version = "0.2.2"
 name = "Maven"
 clear-env = true
+homepage = "https://github.com/heroku/buildpacks-jvm"
+description = "Official Heroku buildpack for Maven applications."
+keywords = ["java", "maven", "mvn"]
+licenses = ["MIT"]
 
 [[stacks]]
 id = "heroku-18"

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -4,6 +4,9 @@ api = "0.4"
 id = "heroku/java-function"
 version = "0.3.3"
 name = "Java Function"
+homepage = "https://github.com/heroku/buildpacks-jvm"
+keywords = ["java", "function"]
+licenses = ["MIT"]
 
 [[order]]
 

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -4,6 +4,10 @@ api = "0.4"
 id = "heroku/java"
 version = "0.3.3"
 name = "Java"
+homepage = "https://github.com/heroku/buildpacks-jvm"
+description = "Official Heroku buildpack for Java applications."
+keywords = ["java"]
+licenses = ["MIT"]
 
 [[order]]
 

--- a/shimmed-buildpacks/clojure/buildpack.toml
+++ b/shimmed-buildpacks/clojure/buildpack.toml
@@ -4,6 +4,10 @@ api = "0.4"
 id = "heroku/clojure"
 version = "0.0.86"
 name = "Clojure"
+homepage = "https://github.com/heroku/heroku-buildpack-clojure"
+description = "Official Heroku buildpack for Clojure applications. It uses Leiningen for building."
+keywords = ["clojure", "leiningen"]
+licenses = ["MIT"]
 
 [[stacks]]
 id = "heroku-18"

--- a/shimmed-buildpacks/gradle/buildpack.toml
+++ b/shimmed-buildpacks/gradle/buildpack.toml
@@ -4,6 +4,10 @@ api = "0.4"
 id = "heroku/gradle"
 version = "0.0.34"
 name = "Gradle"
+homepage = "https://github.com/heroku/heroku-buildpack-gradle"
+description = "Official Heroku buildpack for Gradle applications."
+keywords = ["java", "gradle"]
+licenses = ["MIT"]
 
 [[stacks]]
 id = "heroku-18"

--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -4,6 +4,10 @@ api = "0.4"
 id = "heroku/scala"
 version = "0.0.88"
 name = "Scala"
+homepage = "https://github.com/heroku/heroku-buildpack-scala"
+description = "Official Heroku buildpack for Scala applications. It uses sbt for building."
+keywords = ["scala", "sbt"]
+licenses = ["MIT"]
 
 [[stacks]]
 id = "heroku-18"


### PR DESCRIPTION
In anticipation of GA for the official Cloud Native Buildpack registry, this PR adds missing metadata to the buildpacks in this repository.

Closes [W-8925222](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000097HLvIAM/view)