### PR TITLE
Update Java function runtime to 0.1.1-ea

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Fixed `licenses` in `buildpack.toml`
+* Updated function runtime to `0.1.1-ea`
 
 ## [0.2.3] 2021/02/23
 

--- a/buildpacks/jvm-function-invoker/bin/build
+++ b/buildpacks/jvm-function-invoker/bin/build
@@ -55,9 +55,7 @@ else
 
 		[metadata]
 		runtime_jar_url = "${runtime_jar_url}"
-
-		# See commented code below on why this is currently not used
-		# runtime_jar_sha256 = "${runtime_jar_sha256}"
+		runtime_jar_sha256 = "${runtime_jar_sha256}"
 	EOF
 	log::cnb::debug "Function runtime layer successfully created"
 
@@ -71,16 +69,13 @@ else
 	fi
 	log::cnb::info "Function runtime download successful"
 
-	# SHA256 checksum checking is disabled for as the function runtime is very unstable and is updated very often.
-	# We don't want to trigger a whole release cycle just for a minor update. This code must be reactivated for beta/GA!
-
-	#if ! bputils::check_sha256 "${runtime_layer_jar_path}" "${runtime_jar_sha256}"; then
-	#	log::cnb::error "Function runtime integrity check failed" <<-EOF
-	#		We could not verify the integrity of the downloaded function runtime.
-	#		Please try again and contact us should the error persist.
-	#	EOF
-	#	exit 1
-	#fi
+	if ! bputils::check_sha256 "${runtime_layer_jar_path}" "${runtime_jar_sha256}"; then
+		log::cnb::error "Function runtime integrity check failed" <<-EOF
+			We could not verify the integrity of the downloaded function runtime.
+			Please try again and contact us should the error persist.
+		EOF
+		exit 1
+	fi
 
 	log::cnb::info "Function runtime installation successful"
 fi
@@ -158,5 +153,5 @@ log::cnb::info "Return type: $(log::cnb::bold "$(yj -t <"${bundle_toml}" | jq -r
 cat >>"${layers_dir}/launch.toml" <<-EOF
 	[[processes]]
 	type = "web"
-	command = "java -jar ${runtime_layer_jar_path} serve ${function_bundle_layer_dir} -p \${PORT:-8080}"
+	command = "java -jar ${runtime_layer_jar_path} serve ${function_bundle_layer_dir} -h 0.0.0.0 -p \${PORT:-8080}"
 EOF

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -23,8 +23,8 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://sf-fx-java-internal-early-access.s3.amazonaws.com/sf-fx-runtime-java-1.0-SNAPSHOT-jar-with-dependencies.jar"
-sha256 = "d29275cf21f27b12a0cf4c3b82fbcdfb512a5840792e2acbb0301d25d22d2074"
+url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/0.1.1-ea/sf-fx-runtime-java-runtime-0.1.1-ea-jar-with-dependencies.jar"
+sha256 = "b30ba50b967944120da9262832ea89c403bfefb578efbf08196af725f5e94cd0"
 
 [metadata.release]
 


### PR DESCRIPTION
This change also re-enables integrity checking of the downloaded runtime binary.