### PR TITLE
Add support for SF_FX_REMOTE_DEBUG

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Support for the `SF_FN_REMOTE_DEBUG` runtime environment variable. If set, the invoker will listen for incoming JDWP
+  connections on port `5005`.
+
 ### Changed
 * Detection now checks for `project.toml` in addition to `function.toml` to determine if an app is a function.
 

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -4,7 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-* Support for the `SF_FN_REMOTE_DEBUG` runtime environment variable. If set, the invoker will listen for incoming JDWP
+* Support for the `SF_FX_REMOTE_DEBUG` runtime environment variable. If set, the invoker will listen for incoming JDWP
   connections on port `5005`.
 
 ### Changed

--- a/buildpacks/jvm-function-invoker/bin/build
+++ b/buildpacks/jvm-function-invoker/bin/build
@@ -24,6 +24,21 @@ export_env_vars+=("HEROKU_BUILDPACK_DEBUG")
 bputils::export_env "${platform_dir}" "${export_env_vars[@]}"
 
 ########################################################################################################################
+# Create opt layer
+########################################################################################################################
+opt_layer_dir="${layers_dir}/opt"
+opt_layer_toml="${layers_dir}/opt.toml"
+mkdir -p "${opt_layer_dir}"
+
+cat >"${opt_layer_toml}" <<-EOF
+	launch = true
+	build = true
+	cache = false
+EOF
+
+cp -a "${CNB_BUILDPACK_DIR}/opt/." "${opt_layer_dir}/"
+
+########################################################################################################################
 # Install Java function runtime
 ########################################################################################################################
 log::cnb::header "Installing Java function runtime"
@@ -153,5 +168,5 @@ log::cnb::info "Return type: $(log::cnb::bold "$(yj -t <"${bundle_toml}" | jq -r
 cat >>"${layers_dir}/launch.toml" <<-EOF
 	[[processes]]
 	type = "web"
-	command = "java -jar ${runtime_layer_jar_path} serve ${function_bundle_layer_dir} -h 0.0.0.0 -p \${PORT:-8080}"
+	command = "${opt_layer_dir}/run.sh ${runtime_layer_jar_path} ${function_bundle_layer_dir}"
 EOF

--- a/buildpacks/jvm-function-invoker/opt/run.sh
+++ b/buildpacks/jvm-function-invoker/opt/run.sh
@@ -16,5 +16,5 @@ if [[ -n "${SF_FX_REMOTE_DEBUG:-""}" ]]; then
 	fi
 fi
 
-java "${additional_java_args[@]}" \
+exec java "${additional_java_args[@]}" \
 	-jar "${runtime_layer_jar_path}" serve "${function_bundle_layer_dir}" -h 0.0.0.0 -p "${PORT:-8080}"

--- a/buildpacks/jvm-function-invoker/opt/run.sh
+++ b/buildpacks/jvm-function-invoker/opt/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+runtime_layer_jar_path="${1}"
+function_bundle_layer_dir="${2}"
+
+additional_java_args=()
+if [[ -n "${SF_FN_REMOTE_DEBUG}" ]]; then
+	java_version=$(java -version 2>&1 | grep -i version | awk '{gsub(/"/, "", $3); print $3}')
+
+	if [[ "${java_version}" == 1.8* ]]; then
+		additional_java_args+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005")
+	else
+		additional_java_args+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005")
+	fi
+fi
+
+java "${additional_java_args[@]}" \
+	-jar "${runtime_layer_jar_path}" serve "${function_bundle_layer_dir}" -h 0.0.0.0 -p "${PORT:-8080}"

--- a/buildpacks/jvm-function-invoker/opt/run.sh
+++ b/buildpacks/jvm-function-invoker/opt/run.sh
@@ -4,7 +4,7 @@ runtime_layer_jar_path="${1}"
 function_bundle_layer_dir="${2}"
 
 additional_java_args=()
-if [[ -n "${SF_FN_REMOTE_DEBUG}" ]]; then
+if [[ -n "${SF_FX_REMOTE_DEBUG}" ]]; then
 	java_version=$(java -version 2>&1 | grep -i version | awk '{gsub(/"/, "", $3); print $3}')
 
 	if [[ "${java_version}" == 1.8* ]]; then

--- a/buildpacks/jvm-function-invoker/opt/run.sh
+++ b/buildpacks/jvm-function-invoker/opt/run.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 runtime_layer_jar_path="${1}"
 function_bundle_layer_dir="${2}"
 
 additional_java_args=()
-if [[ -n "${SF_FX_REMOTE_DEBUG}" ]]; then
+if [[ -n "${SF_FX_REMOTE_DEBUG:-""}" ]]; then
 	java_version=$(java -version 2>&1 | grep -i version | awk '{gsub(/"/, "", $3); print $3}')
 
 	if [[ "${java_version}" == 1.8* ]]; then


### PR DESCRIPTION
Add support for the `SF_FX_REMOTE_DEBUG` runtime environment variable. If set, the invoker will listen for incoming JDWP  connections on port `5005`, allowing customers to remotely attach a debugger to debug their function.

Closes [W-9207077](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000KbXWYA0/view)