### PR TITLE
Set M2_HOME for subsequent buildpacks

### DIFF
--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Add documentation to `README.md`
+### Added
+* Documentation in `README.md`
+* `M2_HOME` environment variable is now set for subsequent buildpacks if Maven was installed.
 
 ### Fixed
 * Fixed `licenses` in `buildpack.toml`

--- a/buildpacks/maven/bin/build
+++ b/buildpacks/maven/bin/build
@@ -95,6 +95,14 @@ if ! maven::should_use_wrapper_for_app "${app_dir}"; then
 	chmod +x "${maven_layer_dir}/bin/mvn"
 	export PATH="${PATH}:${maven_layer_dir}/bin"
 
+	mkdir -p "${maven_layer_dir}/env"
+
+	# Even though M2_HOME is no longer supported by Maven versions greater 3.5.0, other tooling such as Maven invoker
+	# might still depend on it. References:
+	# - https://maven.apache.org/docs/3.5.0/release-notes.html#overview-about-the-changes
+	# - https://maven.apache.org/shared/maven-invoker/usage.html
+	echo -n "${maven_layer_dir}" >"${maven_layer_dir}/env/M2_HOME"
+
 	log::cnb::info "Maven installation successful!"
 else
 	log::cnb::info "Maven wrapper detected, skipping installation."


### PR DESCRIPTION
Allows subsequent buildpacks to use installed Maven when they depend on `M2_HOME` being set.

References [W-9041788](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000008sWEYAY/view)
Closes [W-9155483](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000BDqCYAW/view)