### PR TITLE
remove warning in jvm buildpack, deprecation of version field

### DIFF
--- a/buildpacks/jvm/bin/detect
+++ b/buildpacks/jvm/bin/detect
@@ -42,6 +42,8 @@ name = "jdk"
 
 [[requires]]
 name = "jdk"
+
+[requires.metadata]
 version = "$fullJdkVersion"
 
 [[provides]]
@@ -49,6 +51,8 @@ name = "jre"
 
 [[requires]]
 name = "jre"
+
+[requires.metadata]
 version = "$fullJdkVersion"
 TOML
 }


### PR DESCRIPTION
The JVM buildpack currently is using an old Buildpack API with the Build Plan:

```
===> DETECTING
Warning: Warning: buildpack heroku/jvm has a "version" key. This key is deprecated in build plan requirements in buildpack API 0.3. "metadata.version" should be used instead
```

This PR fixes this and uses the new format.