### PR TITLE
Update JVM function runtime to 1.0.0

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Change implementation to Rust
+* Changed implementation to Rust
+* Updated function runtime to `1.0.0`
 
 ## [0.2.11] 2021/05/21
 * Updated function runtime to `0.2.4`

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/jvm-function-invoker"
-version = "0.2.12"
+version = "0.3.0"
 name = "JVM Function Invoker"
 clear-env = true
 homepage = "https://github.com/heroku/buildpacks-jvm"
@@ -23,8 +23,8 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/0.2.4/sf-fx-runtime-java-runtime-0.2.4-jar-with-dependencies.jar"
-sha256 = "7b7da5bb93236f47be1a8397cbdc5d9ec12fe80cc05a1f0ff0b6e13d1a7f20db"
+url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.0.0/sf-fx-runtime-java-runtime-1.0.0-jar-with-dependencies.jar"
+sha256 = "dcd4b399d73b3963e2e4f984b269d4c2f64de76a736379fc3687b2204bb19161"
 
 [metadata.release]
 

--- a/test/meta-buildpacks/java-function/buildpack.toml
+++ b/test/meta-buildpacks/java-function/buildpack.toml
@@ -17,4 +17,4 @@ version = "0.2.4"
 
 [[order.group]]
 id = "heroku/jvm-function-invoker"
-version = "0.2.12"
+version = "0.3.0"


### PR DESCRIPTION
Also bumps version to `0.3.0` to indicate the first version of the buildpack after the switch to Rust as the implementation language.

References [GUS-W-9562648](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000QSSpYAO/view)