### PR TITLE
support for any linux stack 

### DIFF
--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Loosen stack requiremets allowing any linux distro use this buildpacak
 
 ## [0.2.3] 2021/05/05
 ### Added

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.4"
+api = "0.5"
 
 [buildpack]
 id = "heroku/maven"
@@ -20,6 +20,10 @@ id = "heroku-20"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+
+# The buildpack does not use any platform specific tooling, but are only tested against heroku/ubuntu stacks.
+[[stacks]]
+id = "*"
 
 [metadata]
 


### PR DESCRIPTION
This allows any linux distro to use the maven CNB since it isn't platform specific. The any stack stack id is [supported starting in buildpack API `0.5`](https://github.com/buildpacks/spec/issues/140), so I bumped that.