### PR TITLE
Update OpenJDK for Java 16 to 16.0.2

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Default version for **OpenJDK 11** is now `11.0.12`
 * Default version for **OpenJDK 13** is now `13.0.8`
 * Default version for **OpenJDK 15** is now `15.0.4`
+* Default version for **OpenJDK 16** is now `16.0.2`
 
 ## [0.1.6] 2021/04/29
 ### Changed

--- a/buildpacks/jvm/lib/jvm.sh
+++ b/buildpacks/jvm/lib/jvm.sh
@@ -17,7 +17,7 @@ DEFAULT_JDK_12_VERSION="12.0.2"
 DEFAULT_JDK_13_VERSION="13.0.8"
 DEFAULT_JDK_14_VERSION="14.0.2"
 DEFAULT_JDK_15_VERSION="15.0.4"
-DEFAULT_JDK_16_VERSION="16.0.1"
+DEFAULT_JDK_16_VERSION="16.0.2"
 
 if [[ -n "${JDK_BASE_URL}" ]]; then
 	# Support for setting JDK_BASE_URL had the issue that it has to contain the stack name. This makes it hard to


### PR DESCRIPTION
Fixes GUS-W-8657382.