### PR TITLE
Update JVM function runtime to 1.0.0 

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 * Revert all changes from `0.3.0`
+* Updated function runtime to `1.0.0` again
 
 ## [0.3.0] 2021/07/15
 * Changed implementation to Rust

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/jvm-function-invoker"
-version = "0.3.1"
+version = "0.4.0"
 name = "JVM Function Invoker"
 clear-env = true
 homepage = "https://github.com/heroku/buildpacks-jvm"

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -23,8 +23,8 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/0.2.4/sf-fx-runtime-java-runtime-0.2.4-jar-with-dependencies.jar"
-sha256 = "7b7da5bb93236f47be1a8397cbdc5d9ec12fe80cc05a1f0ff0b6e13d1a7f20db"
+url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.0.0/sf-fx-runtime-java-runtime-1.0.0-jar-with-dependencies.jar"
+sha256 = "dcd4b399d73b3963e2e4f984b269d4c2f64de76a736379fc3687b2204bb19161"
 
 [metadata.release]
 

--- a/test/meta-buildpacks/java-function/buildpack.toml
+++ b/test/meta-buildpacks/java-function/buildpack.toml
@@ -17,4 +17,4 @@ version = "0.2.5"
 
 [[order.group]]
 id = "heroku/jvm-function-invoker"
-version = "0.3.1"
+version = "0.4.0"


### PR DESCRIPTION
Same as #113 but for the bash version of the buildpack after we reverted back to it in #123. Also bumps the buildpack version to `0.4.0` to better indicate this major change compared to it being released as`0.3.1`.