### PR TITLE
Switch ECR registry URLs to use custom registry alias

### DIFF
--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -29,4 +29,4 @@ sha256 = "dcd4b399d73b3963e2e4f984b269d4c2f64de76a736379fc3687b2204bb19161"
 [metadata.release]
 
 [metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-jvm-function-invoker-buildpack"
+repository = "public.ecr.aws/heroku-buildpacks/heroku-jvm-function-invoker-buildpack"

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -25,4 +25,4 @@ id = "io.buildpacks.stacks.bionic"
 [metadata.release]
 
 [metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack"
+repository = "public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -29,4 +29,4 @@ id = "*"
 [metadata.release]
 
 [metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-maven-buildpack"
+repository = "public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack"

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -29,4 +29,4 @@ version = "0.4.0"
 [metadata.release]
 
 [metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack"
+repository = "public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack"

--- a/meta-buildpacks/java-function/package.toml
+++ b/meta-buildpacks/java-function/package.toml
@@ -2,10 +2,10 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack@sha256:48329bde18dbd45b66ae912e432044f1dd59c814f7081881471af41d7b8ef43b"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:48329bde18dbd45b66ae912e432044f1dd59c814f7081881471af41d7b8ef43b"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack@sha256:de5997ef358f4b490df3b24386f00665c20c31aeab600856e144fdd62a4c50fb"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:de5997ef358f4b490df3b24386f00665c20c31aeab600856e144fdd62a4c50fb"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-function-invoker-buildpack@sha256:b54124c39d96f5813748d0e5c86c23ecdf989423e2c914f422671831020472e2"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-function-invoker-buildpack@sha256:b54124c39d96f5813748d0e5c86c23ecdf989423e2c914f422671831020472e2"

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -42,4 +42,4 @@ optional = true
 [metadata.release]
 
 [metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-java-buildpack"
+repository = "public.ecr.aws/heroku-buildpacks/heroku-java-buildpack"

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -2,13 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack@sha256:48329bde18dbd45b66ae912e432044f1dd59c814f7081881471af41d7b8ef43b"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:48329bde18dbd45b66ae912e432044f1dd59c814f7081881471af41d7b8ef43b"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack@sha256:de5997ef358f4b490df3b24386f00665c20c31aeab600856e144fdd62a4c50fb"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:de5997ef358f4b490df3b24386f00665c20c31aeab600856e144fdd62a4c50fb"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack@sha256:3ee7cce8ba4f2c7496a92aae18a720016a3dccbec44c81e6a68f213a681dabbc"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-gradle-buildpack@sha256:3ee7cce8ba4f2c7496a92aae18a720016a3dccbec44c81e6a68f213a681dabbc"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/procfile-cnb@sha256:b078c148796dd3cff2bb1ac7a0632cf9f4b558bda3161cd0f869010f72c87558"

--- a/shimmed-buildpacks/clojure/buildpack.toml
+++ b/shimmed-buildpacks/clojure/buildpack.toml
@@ -29,4 +29,4 @@ sha256 = "86710aaba11ece315caefaad15db57153374c69846ac451c890505a28032ae68"
 [metadata.release]
 
 [metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-clojure-buildpack"
+repository = "public.ecr.aws/heroku-buildpacks/heroku-clojure-buildpack"

--- a/shimmed-buildpacks/gradle/buildpack.toml
+++ b/shimmed-buildpacks/gradle/buildpack.toml
@@ -29,4 +29,4 @@ sha256 = "d49db802898e14667ddd98548baf244527875eb6ae4f556c417042540655660c"
 [metadata.release]
 
 [metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack"
+repository = "public.ecr.aws/heroku-buildpacks/heroku-gradle-buildpack"

--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -29,4 +29,4 @@ sha256 = "31510a9f100ddf8d0427f0e9a840a95e565a8942ad46be35902d87e2235a525a"
 [metadata.release]
 
 [metadata.release.docker]
-repository = "public.ecr.aws/r2f9u0w4/heroku-scala-buildpack"
+repository = "public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack"


### PR DESCRIPTION
The ECR registry to which we publish our images has a custom alias of `heroku-buildpacks` that can be used in place of the raw registry name.

The Node.js CNBs have been using this for some time.

Fixes GUS-W-9672346.