### PR TITLE
Ensure the user-provided mvnw wrapper script is executable

### DIFF
--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -4,9 +4,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Ensures `mvnw` is executable
+
 ## [0.2.4] 2021/07/16
 ### Added
-* Loosen stack requiremets allowing any linux distro use this buildpacak
+* Loosen stack requiremets allowing any linux distro use this buildpack
 
 ## [0.2.3] 2021/05/05
 ### Added

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
 * Ensures `mvnw` is executable
 
 ## [0.2.4] 2021/07/16

--- a/buildpacks/maven/bin/build
+++ b/buildpacks/maven/bin/build
@@ -114,6 +114,7 @@ fi
 maven_executable="mvn"
 if maven::should_use_wrapper_for_app "${app_dir}"; then
 	maven_executable="./mvnw"
+	chmod +x "${maven_executable}"
 fi
 
 maven_options=()
@@ -184,11 +185,6 @@ log::cnb::debug "Internal Maven options: ${internal_maven_options[*]}"
 # buildpack, the amount of memory is set to 1GB for now.
 export MAVEN_OPTS="${MAVEN_JAVA_OPTS:-"-Xmx1024m"}"
 log::cnb::debug "Setting MAVEN_OPTS=${MAVEN_OPTS}"
-
-# Ensure customer vendored maven is executable
-if [ -f "${maven_executable}" ]; then
-	chmod +x "${maven_executable}"
-fi
 
 if ! ${maven_executable} "${maven_options[@]}" "${internal_maven_options[@]}" "${maven_goals[@]}"; then
 	log::cnb::error "Failed to build app with Maven" <<-EOF

--- a/buildpacks/maven/bin/build
+++ b/buildpacks/maven/bin/build
@@ -185,6 +185,11 @@ log::cnb::debug "Internal Maven options: ${internal_maven_options[*]}"
 export MAVEN_OPTS="${MAVEN_JAVA_OPTS:-"-Xmx1024m"}"
 log::cnb::debug "Setting MAVEN_OPTS=${MAVEN_OPTS}"
 
+# Ensure customer vendored maven is executable
+if [ -f "${maven_executable}" ]; then
+	chmod +x "${maven_executable}"
+fi
+
 if ! ${maven_executable} "${maven_options[@]}" "${internal_maven_options[@]}" "${maven_goals[@]}"; then
 	log::cnb::error "Failed to build app with Maven" <<-EOF
 		We're sorry this build is failing! If you can't find the issue in application code,

--- a/test/specs/maven/misc_spec.rb
+++ b/test/specs/maven/misc_spec.rb
@@ -1,6 +1,17 @@
 require_relative "spec_helper"
 
 describe "Heroku's Maven Cloud Native Buildpack" do
+  it "will ensure mvn is executable regardless of file permissions" do
+    Cutlass::App.new("simple-http-service").transaction do |app|
+      FileUtils.chmod(0444, app.tmpdir.join("mvnw")) # Set executable to read only on purpose
+
+      app.pack_build do |pack_result|
+        expect(pack_result.stdout).to include("Successfully built image")
+        expect(pack_result.success?).to be_truthy
+      end
+    end
+  end
+
   it "will write ${APP_DIR}/target/mvn-dependency-list.log with the app's dependencies" do
     Cutlass::App.new("simple-http-service", config: {MAVEN_CUSTOM_GOALS: "clean"}).transaction do |app|
       app.pack_build do |pack_result|


### PR DESCRIPTION
If a developer has accidentally changed the permissions on their `mvnw` executable they should be able to deploy.

GUS-W-9689448