### PR TITLE
Make Check Changelog compatible with actions/checkout v2

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -2,10 +2,10 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, labeled]
+    types: [opened, reopened, edited, labeled, unlabeled, synchronize]
 
 jobs:
-  check:
+  check-changelog:
     runs-on: ubuntu-latest
     if: |
       !contains(github.event.pull_request.body, '[skip changelog]') &&
@@ -15,4 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Check that CHANGELOG is touched
-        run: git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1 && \
+          git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md


### PR DESCRIPTION
The GitHub action `actions/checkout` now only shallow clones the Git repo as of v2+, meaning the Check Changelog action fails with:
`fatal: ambiguous argument 'remotes/origin/main': unknown revision or path not in the working tree.`

To fix, an explicit `git fetch` has been added of the HEAD of the default branch.

In addition, the event types on which the check is run has been updated to include missing event types:
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request

Refs GUS-W-9728468.