### PR TITLE
Fix Dependabot configuration for Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
     labels:
       - "skip changelog"
   - package-ecosystem: "cargo"
-    directory: "/"
+    # TODO: Switch this back to "/" once this repo is using cargo workspaces.
+    directory: "/buildpacks/jvm-function-invoker"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
Since Dependabot is looking in the repo root, and that only works if either the crate exists there, or the repo is using [cargo workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html) with a suitably configured repo root `Cargo.toml`.

Until this repo uses cargo workspaces (and the build scripts are adapted to work with workspaces), the Dependabot config needs to reference each crate path explicitly.

Fixes the error seen here:
https://github.com/heroku/buildpacks-jvm/network/updates/191049380

GUS-W-9839985.