### PR TITLE
function-invoker: Enable `clippy::pedantic` and `unused_crate_dependencies` lints

### DIFF
--- a/buildpacks/jvm-function-invoker/src/build.rs
+++ b/buildpacks/jvm-function-invoker/src/build.rs
@@ -10,6 +10,8 @@ use crate::layers::opt::OptLayerLifecycle;
 use crate::layers::runtime::RuntimeLayerLifecycle;
 use crate::JvmFunctionInvokerBuildpackMetadata;
 
+// https://github.com/Malax/libcnb.rs/issues/63
+#[allow(clippy::needless_pass_by_value)]
 pub fn build(
     context: BuildContext<GenericPlatform, JvmFunctionInvokerBuildpackMetadata>,
 ) -> Result<(), libcnb::Error<JvmFunctionInvokerBuildpackError>> {

--- a/buildpacks/jvm-function-invoker/src/detect.rs
+++ b/buildpacks/jvm-function-invoker/src/detect.rs
@@ -8,6 +8,10 @@ use crate::JvmFunctionInvokerBuildpackMetadata;
 use libherokubuildpack::toml_select_value;
 use toml::Value;
 
+// https://github.com/Malax/libcnb.rs/issues/63
+#[allow(clippy::needless_pass_by_value)]
+// https://github.com/Malax/libcnb.rs/issues/86
+#[allow(clippy::unnecessary_wraps)]
 pub fn detect(
     context: DetectContext<GenericPlatform, JvmFunctionInvokerBuildpackMetadata>,
 ) -> Result<DetectOutcome, Error<JvmFunctionInvokerBuildpackError>> {
@@ -31,7 +35,7 @@ fn project_toml_salesforce_type_is_function(project_toml_path: &Path) -> bool {
         .ok()
         .and_then(|table: Value| {
             toml_select_value(vec!["com", "salesforce", "type"], &table)
-                .and_then(|value| value.as_str())
+                .and_then(toml::Value::as_str)
                 .map(|value| value == "function")
         })
         .unwrap_or(false)

--- a/buildpacks/jvm-function-invoker/src/main.rs
+++ b/buildpacks/jvm-function-invoker/src/main.rs
@@ -1,3 +1,11 @@
+// Enable rustc and Clippy lints that are disabled by default.
+// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
+#![warn(unused_crate_dependencies)]
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+// Re-disable pedantic lints that are too noisy/unwanted.
+#![allow(clippy::module_name_repetitions)]
+
 use std::fmt::Debug;
 
 use crate::error::handle_buildpack_error;


### PR DESCRIPTION
Clippy has a `pedantic` lint category for lints that are more opinionated, or that sometimes have a higher false positive rate.

Many of these lints are actually very useful (particularly for those new to Rust, like we are), and so we should take advantage of them - with the understanding that it's absolutely fine to disable individual pedantic lints in the future that we find annoying/counter-productive.

The list of all Clippy lints by category can be found here:
https://rust-lang.github.io/rust-clippy/stable/index.html

In addition, the `unused_crate_dependencies` lint has been enabled to ensure the crate doesn't have unused dependencies:
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies

This is a port of:
https://github.com/heroku/heroku-buildpacks-repo-template/pull/6
https://github.com/heroku/heroku-buildpacks-repo-template/pull/7
https://github.com/heroku/heroku-buildpacks-repo-template/pull/8

GUS-W-9888451.
GUS-W-9888470.