### PR TITLE
Update CI to Rust 1.55

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       buildpack-dir:
         type: string
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.55
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Most of the CI jobs are installing Rust stable themselves (so are already using Rust 1.55), however this one is using `cimg/rust` (causing the rustup install script to not update major version), so needs updating explicitly.

Refactoring the CI jobs to use the optimal combination of images/install steps will happen in later PRs (it's more involved since it requires splitting the build and cutlass steps out, so we don't need to use the `machine` executor etc).

The image tag has intentionally been switched to the `1.NN` alias rather than `1.NN.N`, to reduce CI config churn for patch releases, and consistency with the other Rust repos.

Release notes:
https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html
https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html

GUS-W-9885998.