### PR TITLE
Update meta-buildpacks jvm-function-invoker to 0.5.3

### DIFF
--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Upgraded `heroku/jvm-function-invoker` to `0.5.3`
 
 ## [0.3.18] 2021/09/15
 * Upgraded `heroku/jvm` to `0.1.8`

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -22,7 +22,7 @@ version = "0.2.5"
 
 [[order.group]]
 id = "heroku/jvm-function-invoker"
-version = "0.5.2"
+version = "0.5.3"
 
 [metadata]
 


### PR DESCRIPTION
[Release of jvm-function-invoker to 0.5.3](https://github.com/heroku/buildpacks-jvm/pull/168)
[W-9950528](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000As3fyYAB)