### PR TITLE
Failing test for logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cutlass (0.2.3)
+    cutlass (0.2.4)
       docker-api (>= 2.0)
     dead_end (1.1.7)
     diff-lcs (1.4.4)
     docker-api (2.2.0)
       excon (>= 0.47.0)
       multi_json
-    excon (0.85.0)
+    excon (0.86.0)
     java-properties (0.3.0)
     multi_json (1.15.0)
     rspec-core (3.10.1)
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-retry
 
 BUNDLED WITH
-   2.2.16
+   2.2.27

--- a/test/fixtures/simple-function/pom.xml
+++ b/test/fixtures/simple-function/pom.xml
@@ -21,6 +21,11 @@
             <artifactId>sf-fx-sdk-java</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test/fixtures/simple-function/src/main/java/com/example/ExampleFunction.java
+++ b/test/fixtures/simple-function/src/main/java/com/example/ExampleFunction.java
@@ -4,9 +4,15 @@ import com.salesforce.functions.jvm.sdk.Context;
 import com.salesforce.functions.jvm.sdk.InvocationEvent;
 import com.salesforce.functions.jvm.sdk.SalesforceFunction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ExampleFunction implements SalesforceFunction<String, String> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExampleFunction.class);
+
   @Override
   public String apply(InvocationEvent<String> event, Context context) {
+    LOGGER.info("logging info 1");
     return new StringBuilder(event.getData()).reverse().toString();
   }
 }

--- a/test/specs/java-function/function_spec.rb
+++ b/test/specs/java-function/function_spec.rb
@@ -15,6 +15,8 @@ describe "Heroku's Java CNB" do
           body: body
         ).call
 
+        expect(container.logs.stdout).to include("logging info 1")
+
         expect(query.as_json).to eq(body.reverse)
         expect(query.success?).to be_truthy
       end


### PR DESCRIPTION
It was reported that no logs are coming out of the logger interface for the java function. We currently have no tests asserting log output is being emitted from functions. This commit exercises a logger and adds a (failing) assertion that the contents of that logger is then emitted from the container logs.

GUS-W-9933414

Java logging test: https://github.com/heroku/buildpacks-jvm/pull/175
Node logging test: https://github.com/heroku/buildpacks-nodejs/pull/135