### PR TITLE
Don't use /dev/random for entropy in SecureRandom usage

### DIFF
--- a/buildpacks/jvm-function-invoker/opt/run.sh
+++ b/buildpacks/jvm-function-invoker/opt/run.sh
@@ -16,5 +16,7 @@ if [[ -n "${DEBUG_PORT:-""}" ]]; then
 	fi
 fi
 
-exec java "${additional_java_args[@]}" \
+JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom"
+
+exec java "${additional_java_args[@]}" "${JAVA_OPTS}" \
 	-jar "${runtime_layer_jar_path}" serve "${function_bundle_layer_dir}" -h 0.0.0.0 -p "${PORT:-8080}"


### PR DESCRIPTION
`/dev/random` is blocking in linux, which can cause delays in function usage

https://www.baeldung.com/java-security-egd