### PR TITLE
Update Scala buildpack from classic v91

### DIFF
--- a/shimmed-buildpacks/scala/CHANGELOG.md
+++ b/shimmed-buildpacks/scala/CHANGELOG.md
@@ -3,6 +3,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.91]
+This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
+for that release can be found here: https://github.com/heroku/heroku-buildpack-scala/blob/main/CHANGELOG.md#v91
+
 ### Fixed
 * Fixed `licenses` in `buildpack.toml`
 

--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -23,8 +23,8 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.shim]
-tarball = "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/scala-v90.tgz"
-sha256 = "31510a9f100ddf8d0427f0e9a840a95e565a8942ad46be35902d87e2235a525a"
+tarball = "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/scala-v91.tgz"
+sha256 = "a41c61addccd7c24d38e24ecff67b63c9fb03efdaea1735255385a8e0669db69"
 
 [metadata.release]
 


### PR DESCRIPTION
See:
https://github.com/heroku/heroku-buildpack-scala/pull/192

GUS-W-10034641.