### PR TITLE
Bump Scala buildpack version to 0.0.91

### DIFF
--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/scala"
-version = "0.0.90"
+version = "0.0.91"
 name = "Scala"
 homepage = "https://github.com/heroku/heroku-buildpack-scala"
 description = "Official Heroku buildpack for Scala applications. It uses sbt for building."


### PR DESCRIPTION
Missed from #183.

The release process works a bit differently for these shimmed buildpacks - the version isn't already bumped in `buildpack.toml` after the previous release.