### PR TITLE
Update to Rust 1.56 and 2021 edition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       buildpack-dir:
         type: string
     docker:
-      - image: cimg/rust:1.55
+      - image: cimg/rust:1.56
     steps:
       - checkout
       - setup_remote_docker

--- a/buildpacks/jvm-function-invoker/Cargo.toml
+++ b/buildpacks/jvm-function-invoker/Cargo.toml
@@ -2,7 +2,8 @@
 name = "jvm-function-invoker-buildpack"
 version = "0.0.0"
 publish = false
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 indoc = "1.0.3"


### PR DESCRIPTION
Rust 1.56 has just been released:
https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html

Compatibility with the 2021 edition was ensured by running `cargo fix --edition`.

A minimum Rust version has been set using:
https://doc.rust-lang.org/nightly/cargo/reference/manifest.html#the-rust-version-field

GUS-W-10066573.