### PR TITLE
Update OpenJDK default version for 17

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Default version for **OpenJDK 17** is now `17.0.1`
 
 ## [0.1.9] 2021/10/19
 ### Changed

--- a/buildpacks/jvm/lib/jvm.sh
+++ b/buildpacks/jvm/lib/jvm.sh
@@ -18,7 +18,7 @@ DEFAULT_JDK_13_VERSION="13.0.9"
 DEFAULT_JDK_14_VERSION="14.0.2"
 DEFAULT_JDK_15_VERSION="15.0.5"
 DEFAULT_JDK_16_VERSION="16.0.2"
-DEFAULT_JDK_17_VERSION="17.0.0"
+DEFAULT_JDK_17_VERSION="17.0.1"
 
 if [[ -n "${JDK_BASE_URL}" ]]; then
 	# Support for setting JDK_BASE_URL had the issue that it has to contain the stack name. This makes it hard to


### PR DESCRIPTION
OpenJDK releases for the third quarter of 2021

References:
[W-10084724](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000JMShPYAX)