### PR TITLE
Switch to BSD 3-Clause License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,29 @@
-MIT License:
+BSD 3-Clause License
 
-Copyright (C) 2021 Heroku, Inc.
+Copyright (c) 2021, Salesforce.com, Inc.
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ scripts must be located in a file named `build.sh` in the buildpack root directo
 - [jq](https://github.com/stedolan/jq) >= `1.6` in `$PATH`
 
 ## License
-Licensed under the MIT License. See [LICENSE](./LICENSE) file.
+See [LICENSE](./LICENSE) file.

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Switch to BSD 3-Clause License
 
 ## [0.5.5] 2021/10/19
 

--- a/buildpacks/jvm-function-invoker/README.md
+++ b/buildpacks/jvm-function-invoker/README.md
@@ -50,4 +50,4 @@ $ cargo test
 ```
 
 ## License
-Licensed under the MIT License. See [LICENSE](../../LICENSE) file.
+See [LICENSE](../../LICENSE) file.

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/heroku/buildpacks-jvm"
 keywords = ["java", "function"]
 
 [[licenses]]
-type = "MIT"
+type = "BSD-3-Clause"
 
 [[stacks]]
 id = "heroku-18"

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Switch to BSD 3-Clause License
 
 ## [0.1.11] 2021/10/28
 ### Changed

--- a/buildpacks/jvm/README.md
+++ b/buildpacks/jvm/README.md
@@ -1,4 +1,4 @@
 #  Heroku Cloud Native JVM Buildpack
 
 ## License
-Licensed under the MIT License. See [LICENSE](../../LICENSE) file.
+See [LICENSE](../../LICENSE) file.

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -9,7 +9,7 @@ description = "Official Heroku buildpack for installing a JVM."
 keywords = ["java", "jvm", "jdk", "openjdk"]
 
 [[licenses]]
-type = "MIT"
+type = "BSD-3-Clause"
 
 [[stacks]]
 id = "heroku-18"

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Switch to BSD 3-Clause License
 
 ## [0.2.5] 2021/08/10
 ### Fixed

--- a/buildpacks/maven/README.md
+++ b/buildpacks/maven/README.md
@@ -84,4 +84,4 @@ Allows overriding the Java options for the Maven process during build. The defau
 If set, the buildpack will emit debug log messages.
 
 ## License
-Licensed under the MIT License. See [LICENSE](../../LICENSE) file.
+See [LICENSE](../../LICENSE) file.

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -10,7 +10,7 @@ description = "Official Heroku buildpack for Maven applications."
 keywords = ["java", "maven", "mvn"]
 
 [[licenses]]
-type = "MIT"
+type = "BSD-3-Clause"
 
 [[stacks]]
 id = "heroku-18"

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Switch to BSD 3-Clause License
 
 ## [0.3.24] 2021/10/28
 * Upgraded `heroku/jvm` to `0.1.11`

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/heroku/buildpacks-jvm"
 keywords = ["java", "function"]
 
 [[licenses]]
-type = "MIT"
+type = "BSD-3-Clause"
 
 [[order]]
 

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Switch to BSD 3-Clause License
 
 ## [0.3.13] 2021/10/28
 * Upgraded `heroku/jvm` to `0.1.11`

--- a/meta-buildpacks/java/README.md
+++ b/meta-buildpacks/java/README.md
@@ -180,4 +180,4 @@ by default. To use another task, set the `GRADLE_TASK` environment variable to t
 your application.
 
 ## License
-Licensed under the MIT License. See [LICENSE](../../LICENSE) file.
+See [LICENSE](../../LICENSE) file.

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -9,7 +9,7 @@ description = "Official Heroku buildpack for Java applications."
 keywords = ["java"]
 
 [[licenses]]
-type = "MIT"
+type = "BSD-3-Clause"
 
 [[order]]
 

--- a/shimmed-buildpacks/clojure/CHANGELOG.md
+++ b/shimmed-buildpacks/clojure/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed `licenses` in `buildpack.toml`
 
+### Changed
+* Switch to BSD 3-Clause License
+
 ## [0.0.87]
 This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
 for that release can be found here: https://github.com/heroku/heroku-buildpack-clojure/blob/main/CHANGELOG.md#v87

--- a/shimmed-buildpacks/clojure/buildpack.toml
+++ b/shimmed-buildpacks/clojure/buildpack.toml
@@ -9,7 +9,7 @@ description = "Official Heroku buildpack for Clojure applications. It uses Leini
 keywords = ["clojure", "leiningen"]
 
 [[licenses]]
-type = "MIT"
+type = "BSD-3-Clause"
 
 [[stacks]]
 id = "heroku-18"

--- a/shimmed-buildpacks/gradle/CHANGELOG.md
+++ b/shimmed-buildpacks/gradle/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed `licenses` in `buildpack.toml`
 
+### Changed
+* Switch to BSD 3-Clause License
+
 ## [0.0.35] 2021/02/23
 
 ## [0.0.35]

--- a/shimmed-buildpacks/gradle/buildpack.toml
+++ b/shimmed-buildpacks/gradle/buildpack.toml
@@ -9,7 +9,7 @@ description = "Official Heroku buildpack for Gradle applications."
 keywords = ["java", "gradle"]
 
 [[licenses]]
-type = "MIT"
+type = "BSD-3-Clause"
 
 [[stacks]]
 id = "heroku-18"

--- a/shimmed-buildpacks/scala/CHANGELOG.md
+++ b/shimmed-buildpacks/scala/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Switch to BSD 3-Clause License
 
 ## [0.0.91] 2021/10/14
 This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog

--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -9,7 +9,7 @@ description = "Official Heroku buildpack for Scala applications. It uses sbt for
 keywords = ["scala", "sbt"]
 
 [[licenses]]
-type = "MIT"
+type = "BSD-3-Clause"
 
 [[stacks]]
 id = "heroku-18"


### PR DESCRIPTION
Since:
- it's the license Salesforce prefers that we use for open source projects:
  https://github.com/salesforce/oss-template/blob/master/license_info.md
- it's what some of our other newer repositories are already using, and it would be great to be consistent
- it's not that different from MIT:
  https://fossa.com/blog/open-source-software-licenses-101-bsd-3-clause-license/

All contributors to this repository so far are Salesforce employees, so there are no external code contributors from whom we need to ask permission before changing the license type.

GUS-W-10140085.