### PR TITLE
Update to Rust 1.57 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       buildpack-dir:
         type: string
     docker:
-      - image: cimg/rust:1.56
+      - image: cimg/rust:1.57
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html

GUS-W-10261473.