### PR TITLE
Update Pack to v0.23.0 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  pack: buildpacks/pack@0.2.2
+  pack: buildpacks/pack@0.2.4
   heroku-buildpacks:
     commands:
       install-build-dependencies:
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - pack/install-pack:
-          version: 0.22.0
+          version: 0.23.0
       - heroku-buildpacks/install-build-dependencies
       - run:
           name: "Build and package buildpack"
@@ -78,7 +78,7 @@ jobs:
     steps:
       - checkout
       - pack/install-pack:
-          version: 0.22.0
+          version: 0.23.0
       - heroku-buildpacks/install-build-dependencies
       - run:
           name: Install Ruby dependencies


### PR DESCRIPTION
Changes:
https://github.com/buildpacks/pack/releases/tag/v0.23.0
https://github.com/buildpacks/pack-orb/releases/tag/0.2.3
https://github.com/buildpacks/pack-orb/releases/tag/0.2.4

The Pack version bump for the GitHub actions release workflow needs a new release of `buildpacks/github-actions`, after which Dependabot will open a PR. This PR just handles CI (which is good to update first, given the release scripts don't have tests).

GUS-W-10301655.