### PR TITLE
Add star-stack to Gradle buildpack

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -55,9 +55,7 @@ image_name="${buildpack_docker_repository}:${buildpack_version}"
 echo "Publishing ${buildpack_id} v${buildpack_version} to ${image_name}"
 pack package-buildpack --config "${buildpack_build_path}/package.toml" --publish "${image_name}"
 
-org_name=$(dirname "$buildpack_id")
-bp_name=$(basename "$buildpack_id")
-file_name="${org_name}-${bp_name}-${buildpack_version}.tgz"
+file_name="${buildpack_id//\//_}-${buildpack_version}.cnb"
 
 echo "Publishing ${buildpack_id} v${buildpack_version} to ${file_name}"
 pack buildpack package --format file --config "${buildpack_build_path}/package.toml" "${file_name}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.package.outputs.package }}
-          tag: ${{ github.ref }}
+          tag: ${{ steps.package.outputs.id }}_${{ steps.package.outputs.version }}
           overwrite: true
       - id: prepare-pr
         name: "Prepare PR with version bumps and CHANGELOG updates"

--- a/shimmed-buildpacks/gradle/CHANGELOG.md
+++ b/shimmed-buildpacks/gradle/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Switch to BSD 3-Clause License
+* This buildpack now supports all stacks (stacks = "*" in buildpack.toml)
 
 ## [0.0.35] 2021/02/23
 

--- a/shimmed-buildpacks/gradle/buildpack.toml
+++ b/shimmed-buildpacks/gradle/buildpack.toml
@@ -1,8 +1,8 @@
-api = "0.4"
+api = "0.5"
 
 [buildpack]
 id = "heroku/gradle"
-version = "0.0.36"
+version = "0.0.35.1"
 name = "Gradle"
 homepage = "https://github.com/heroku/heroku-buildpack-gradle"
 description = "Official Heroku buildpack for Gradle applications."
@@ -19,6 +19,9 @@ id = "heroku-20"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+id = "*"
 
 [metadata]
 

--- a/test/meta-buildpacks/java/buildpack.toml
+++ b/test/meta-buildpacks/java/buildpack.toml
@@ -24,7 +24,7 @@ optional = true
 
 [[order.group]]
 id = "heroku/gradle"
-version = "0.0.36"
+version = "0.0.35.1"
 
 [[order.group]]
 id = "heroku/procfile"


### PR DESCRIPTION
To support usage of `heroku/gradle` inside of Salesforce, we need to support the `sfdc_centos7` stack. We follow the pattern  from `heroku/maven` here and add the magic star-stack to Gradle's `buildpack.toml`.

In addition, this also fixes the release scripts for pushing to a GitHub release.