### PR TITLE
Fix licenses table in buildpack.toml files

### DIFF
--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -8,7 +8,7 @@ clear-env = true
 homepage = "https://github.com/heroku/buildpacks-jvm"
 keywords = ["java", "function"]
 
-[[licenses]]
+[[buildpack.licenses]]
 type = "BSD-3-Clause"
 
 [[stacks]]

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/heroku/buildpacks-jvm"
 description = "Official Heroku buildpack for installing a JVM."
 keywords = ["java", "jvm", "jdk", "openjdk"]
 
-[[licenses]]
+[[buildpack.licenses]]
 type = "BSD-3-Clause"
 
 [[stacks]]

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/heroku/buildpacks-jvm"
 description = "Official Heroku buildpack for Maven applications."
 keywords = ["java", "maven", "mvn"]
 
-[[licenses]]
+[[buildpack.licenses]]
 type = "BSD-3-Clause"
 
 [[stacks]]

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -7,7 +7,7 @@ name = "Java Function"
 homepage = "https://github.com/heroku/buildpacks-jvm"
 keywords = ["java", "function"]
 
-[[licenses]]
+[[buildpack.licenses]]
 type = "BSD-3-Clause"
 
 [[order]]

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/heroku/buildpacks-jvm"
 description = "Official Heroku buildpack for Java applications."
 keywords = ["java"]
 
-[[licenses]]
+[[buildpack.licenses]]
 type = "BSD-3-Clause"
 
 [[order]]

--- a/shimmed-buildpacks/clojure/buildpack.toml
+++ b/shimmed-buildpacks/clojure/buildpack.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/heroku/heroku-buildpack-clojure"
 description = "Official Heroku buildpack for Clojure applications. It uses Leiningen for building."
 keywords = ["clojure", "leiningen"]
 
-[[licenses]]
+[[buildpack.licenses]]
 type = "BSD-3-Clause"
 
 [[stacks]]

--- a/shimmed-buildpacks/gradle/buildpack.toml
+++ b/shimmed-buildpacks/gradle/buildpack.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/heroku/heroku-buildpack-gradle"
 description = "Official Heroku buildpack for Gradle applications."
 keywords = ["java", "gradle"]
 
-[[licenses]]
+[[buildpack.licenses]]
 type = "BSD-3-Clause"
 
 [[stacks]]

--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/heroku/heroku-buildpack-scala"
 description = "Official Heroku buildpack for Scala applications. It uses sbt for building."
 keywords = ["scala", "sbt"]
 
-[[licenses]]
+[[buildpack.licenses]]
 type = "BSD-3-Clause"
 
 [[stacks]]


### PR DESCRIPTION
@edmorley pointed out to me that the licenses table is wrong for JVM buildpacks. This PR fixes the issue.