### PR TITLE
Install libcnb-cargo instead of cargo-make when releasing

### DIFF
--- a/.github/scripts/release-workflow-package-push.sh
+++ b/.github/scripts/release-workflow-package-push.sh
@@ -55,7 +55,7 @@ image_name="${buildpack_docker_repository}:${buildpack_version}"
 echo "Publishing ${buildpack_id} v${buildpack_version} to ${image_name}"
 pack package-buildpack --config "${buildpack_build_path}/package.toml" --publish "${image_name}"
 
-cnb_package_file_path="${TMPDIR}/${buildpack_id//\//_}-${buildpack_version}.cnb"
+cnb_package_file_path="$(mktemp -d)/${buildpack_id//\//_}-${buildpack_version}.cnb"
 
 echo "Packaging .cnb file for ${buildpack_id} v${buildpack_version} to ${cnb_package_file_path}"
 pack buildpack package --format file --config "${buildpack_build_path}/package.toml" "${cnb_package_file_path}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
         with:
           toolchain: stable
           target: "x86_64-unknown-linux-musl"
-      - id: install-cargo-make
-        name: "Install cargo-make"
+      - id: install-libcnb-cargo
+        name: "Install libcnb-cargo"
         uses: actions-rs/install@v0.1
         with:
-          crate: cargo-make
+          crate: libcnb-cargo
           version: latest
       - id: package
         name: "Package buildpack and publish to container registry"


### PR DESCRIPTION
Fixing https://github.com/heroku/buildpacks-jvm/pull/215#issuecomment-991054661 and other issues (see: #224, #225, #226) in the release action. Successful release run from the code in this branch can be seen here: https://github.com/heroku/buildpacks-jvm/actions/runs/1657597150

Closes GUS-W-10383141