### PR TITLE
Update to Rust 1.58 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       buildpack-dir:
         type: string
     docker:
-      - image: cimg/rust:1.57
+      - image: cimg/rust:1.58
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html

GUS-W-10435310