### PR TITLE
Update heroku/scala to v92

### DIFF
--- a/shimmed-buildpacks/scala/CHANGELOG.md
+++ b/shimmed-buildpacks/scala/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog
+for that release can be found here: https://github.com/heroku/heroku-buildpack-scala/blob/main/CHANGELOG.md#v92
+
 * Switch to BSD 3-Clause License
 
 ## [0.0.91] 2021/10/14

--- a/shimmed-buildpacks/scala/buildpack.toml
+++ b/shimmed-buildpacks/scala/buildpack.toml
@@ -23,8 +23,8 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.shim]
-tarball = "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/scala-v91.tgz"
-sha256 = "a41c61addccd7c24d38e24ecff67b63c9fb03efdaea1735255385a8e0669db69"
+tarball = "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/scala-v92.tgz"
+sha256 = "4081cbf84b9fe6eb1af2a3b3c35345e2a19cfa3df46bd5465ef77e83fcba44bf"
 
 [metadata.release]
 


### PR DESCRIPTION
Update shimmed buildpack to most recent upstream version.

References: GUS-W-10666714