### PR TITLE
Bump to pack 0.26.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - pack/install-pack:
-          version: 0.24.1
+          version: 0.26.0
       - heroku-buildpacks/install-build-dependencies
       - run:
           name: "Build and package buildpack"
@@ -78,7 +78,7 @@ jobs:
     steps:
       - checkout
       - pack/install-pack:
-          version: 0.24.1
+          version: 0.26.0
       - heroku-buildpacks/install-build-dependencies
       - run:
           name: Install Ruby dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - pack/install-pack:
-          version: 0.23.0
+          version: 0.24.1
       - heroku-buildpacks/install-build-dependencies
       - run:
           name: "Build and package buildpack"
@@ -78,7 +78,7 @@ jobs:
     steps:
       - checkout
       - pack/install-pack:
-          version: 0.23.0
+          version: 0.24.1
       - heroku-buildpacks/install-build-dependencies
       - run:
           name: Install Ruby dependencies


### PR DESCRIPTION
There have been a few updates we should pick up (https://github.com/buildpacks/pack/releases/tag/v0.24.0, https://github.com/buildpacks/pack/releases/tag/v0.24.1).

GUS-W-10708989.
GUS-W-11136285.