### PR TITLE
Make Dependabot labels consistent with other repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "skip changelog"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "skip changelog"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "skip changelog"

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -11,7 +11,8 @@ jobs:
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       !contains(github.event.pull_request.body, '[changelog skip]') &&
       !contains(github.event.pull_request.body, '[skip ci]') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog')
+      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - uses: actions/checkout@v3
       - name: Check that CHANGELOG is touched


### PR DESCRIPTION
By default Dependabot sets `dependencies` and `<lang>` labels on PRs it opens. However previously those were overridden by the manual `labels` setting here.

This is inconsistent with how we have other repos configured, and means I can't as easily exclude Dependabot PRs from the PR review reminders GitHub feature that I'm about to enable.