### PR TITLE
Add heroku-22 support

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Upgrade `libcnb` to `0.6.0` and `libherokubuildpack` to `0.6.0`.
+* Add support for the `heroku-22` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))
 
 ## [0.6.1] 2022/02/08
 * Upgrade `libcnb` to `0.5.0` and `libherokubuildpack` to `0.5.0`.

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -18,6 +18,9 @@ id = "heroku-18"
 id = "heroku-20"
 
 [[stacks]]
+id = "heroku-22"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
 [metadata]

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add support for the `heroku-22` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))
+* [Azul Zulu Builds of OpenJDK](https://www.azul.com/downloads/?package=jdk#download-openjdk) is now the default OpenJDK distribution. This change does not affect the `heroku-18` and `heroku-20` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))
+
 ## [1.0.0] 2022/05/17
 
 * Re-implement buildpack using [libcnb.rs](https://github.com/Malax/libcnb.rs) ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -18,6 +18,9 @@ id = "heroku-18"
 id = "heroku-20"
 
 [[stacks]]
+id = "heroku-22"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
 [metadata]

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -66,6 +66,7 @@ impl Buildpack for OpenJdkBuildpack {
             .map_err(OpenJdkBuildpackError::ReadVersionStringError)?;
 
         let normalized_version = version::normalize_version_string(
+            &context.stack_id,
             app_dir_version_string.unwrap_or_else(|| String::from("8")),
         )
         .map_err(OpenJdkBuildpackError::NormalizeVersionStringError)?;

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add support for the `heroku-22` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))
+
 ## [1.0.0] 2022/03/24
 
 * Re-implement buildpack using [libcnb.rs](https://github.com/Malax/libcnb.rs) ([#273](https://github.com/heroku/buildpacks-jvm/pull/273))

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -19,6 +19,9 @@ id = "heroku-18"
 id = "heroku-20"
 
 [[stacks]]
+id = "heroku-22"
+
+[[stacks]]
 id = "*"
 
 [metadata]


### PR DESCRIPTION
Adds `heroku-22` support for all native CNB buildpacks. Shimmed buildpacks will follow when the classic buildpack support for `heroku-22` is completed.

Starting with `heroku-22`, [Azul Zulu Builds of OpenJDK](https://www.azul.com/downloads/?package=jdk#download-openjdk) is now the default OpenJDK distribution. `heroku/jvm` has been modified accordingly.

Closes GUS-W-10343951