### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Switch to the recommended regional S3 domain instead of the global one. ([#314](https://github.com/heroku/buildpacks-jvm/pull/314))
+
 ## [1.0.1] 2022/06/09
 
 * Add support for the `heroku-22` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))

--- a/buildpacks/jvm/src/version.rs
+++ b/buildpacks/jvm/src/version.rs
@@ -61,7 +61,7 @@ pub fn resolve_openjdk_url<V: Into<String>>(
     version_string: V,
 ) -> String {
     let version_string = version_string.into();
-    let base_url = format!("https://lang-jvm.s3.amazonaws.com/jdk/{stack_id}");
+    let base_url = format!("https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/{stack_id}");
 
     let file_name = match distribution {
         OpenJDKDistribution::Heroku => format!("openjdk{version_string}.tar.gz"),
@@ -136,7 +136,7 @@ mod tests {
                 OpenJDKDistribution::Heroku,
                 "1.0.0"
             ),
-            "https://lang-jvm.s3.amazonaws.com/jdk/heroku-20/openjdk1.0.0.tar.gz"
+            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-20/openjdk1.0.0.tar.gz"
         );
 
         assert_eq!(
@@ -145,7 +145,7 @@ mod tests {
                 OpenJDKDistribution::Heroku,
                 "1.2.3"
             ),
-            "https://lang-jvm.s3.amazonaws.com/jdk/heroku-20/openjdk1.2.3.tar.gz"
+            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-20/openjdk1.2.3.tar.gz"
         );
 
         assert_eq!(
@@ -154,7 +154,7 @@ mod tests {
                 OpenJDKDistribution::Heroku,
                 "1.2.3"
             ),
-            "https://lang-jvm.s3.amazonaws.com/jdk/heroku-22/openjdk1.2.3.tar.gz"
+            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-22/openjdk1.2.3.tar.gz"
         );
 
         assert_eq!(
@@ -163,7 +163,7 @@ mod tests {
                 OpenJDKDistribution::Heroku,
                 "1.2.3.4.5-suffix"
             ),
-            "https://lang-jvm.s3.amazonaws.com/jdk/heroku-18/openjdk1.2.3.4.5-suffix.tar.gz"
+            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-18/openjdk1.2.3.4.5-suffix.tar.gz"
         );
     }
 
@@ -175,7 +175,7 @@ mod tests {
                 OpenJDKDistribution::AzulZulu,
                 "1.0.0"
             ),
-            "https://lang-jvm.s3.amazonaws.com/jdk/heroku-20/zulu-1.0.0.tar.gz"
+            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-20/zulu-1.0.0.tar.gz"
         );
 
         assert_eq!(
@@ -184,7 +184,7 @@ mod tests {
                 OpenJDKDistribution::AzulZulu,
                 "1.2.3"
             ),
-            "https://lang-jvm.s3.amazonaws.com/jdk/heroku-20/zulu-1.2.3.tar.gz"
+            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-20/zulu-1.2.3.tar.gz"
         );
 
         assert_eq!(
@@ -193,7 +193,7 @@ mod tests {
                 OpenJDKDistribution::AzulZulu,
                 "1.2.3"
             ),
-            "https://lang-jvm.s3.amazonaws.com/jdk/heroku-22/zulu-1.2.3.tar.gz"
+            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-22/zulu-1.2.3.tar.gz"
         );
 
         assert_eq!(
@@ -202,7 +202,7 @@ mod tests {
                 OpenJDKDistribution::AzulZulu,
                 "1.2.3.4.5-suffix"
             ),
-            "https://lang-jvm.s3.amazonaws.com/jdk/heroku-18/zulu-1.2.3.4.5-suffix.tar.gz"
+            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-18/zulu-1.2.3.4.5-suffix.tar.gz"
         );
     }
 }

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Switch to the recommended regional S3 domain instead of the global one. ([#314](https://github.com/heroku/buildpacks-jvm/pull/314))
+
 ## [1.0.1] 2022/06/09
 
 * Add support for the `heroku-22` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -30,19 +30,19 @@ default-version = "3.6.2"
 [metadata.tarballs]
 
 [metadata.tarballs."3.2.5"]
-url = "https://lang-jvm.s3.amazonaws.com/maven-3.2.5.tar.gz"
+url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.2.5.tar.gz"
 sha256 = "bd37fad4863cd01524f31ada88ce9f0632040976d64561157cafc98959764341"
 
 [metadata.tarballs."3.6.2"]
-url = "https://lang-jvm.s3.amazonaws.com/maven-3.6.2.tar.gz"
+url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.6.2.tar.gz"
 sha256 = "63fe4e0bf88d5ec732736f4baa2b62172e654130e16c1db02c252c639b9fd3df"
 
 [metadata.tarballs."3.5.4"]
-url = "https://lang-jvm.s3.amazonaws.com/maven-3.5.4.tar.gz"
+url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.5.4.tar.gz"
 sha256 = "2fa7a911bfef93a3bc0699674efd307a53da28f9179a50b10d183080b1f5bbc0"
 
 [metadata.tarballs."3.3.9"]
-url = "https://lang-jvm.s3.amazonaws.com/maven-3.3.9.tar.gz"
+url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.3.9.tar.gz"
 sha256 = "72e5a073cd1acb8925a55366a37268d28a5bdde76d4cda4888364068472aa46e"
 
 [metadata.release]


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

Our buildpack buckets are in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`:
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.