### PR TITLE
Update libcnb.rs URLs for migration to the heroku org

### DIFF
--- a/buildpacks/jvm-function-invoker/README.md
+++ b/buildpacks/jvm-function-invoker/README.md
@@ -13,10 +13,10 @@
 * [pack](https://buildpacks.io/docs/tools/pack/) (for local development)
 
 ## Usage
-This buildpack targets `x86_64-unknown-linux-musl` as the platform for the buildpack. It uses [`libcnb.rs`](https://github.com/Malax/libcnb.rs) as the language binding for buildpacks which cames with tooling for cross-compilation and packagaing.
+This buildpack targets `x86_64-unknown-linux-musl` as the platform for the buildpack. It uses [`libcnb.rs`](https://github.com/heroku/libcnb.rs) as the language binding for buildpacks which cames with tooling for cross-compilation and packagaing.
 
 ### Development
-Use [`libcnb-cargo`](https://github.com/Malax/libcnb.rs/tree/main/libcnb-cargo) to cross-compile and build the buildpack for local development and testing:
+Use [`libcnb-cargo`](https://github.com/heroku/libcnb.rs/tree/main/libcnb-cargo) to cross-compile and build the buildpack for local development and testing:
 
 ```shell
 $ cargo libcnb package

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] 2022/05/17
 
-* Re-implement buildpack using [libcnb.rs](https://github.com/Malax/libcnb.rs) ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
+* Re-implement buildpack using [libcnb.rs](https://github.com/heroku/libcnb.rs) ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
 * Remove support for GPG signed OpenJDK binaries. This feature wasn't used and will be replaced by a unified solution across Heroku buildpacks. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
 * Remove support for the `JDK_BASE_URL` environment variable. It was deprecated in Jan 2021 and was slated for removal Oct 2021. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
 * Remove support for the `JVM_BUILDPACK_ASSETS_BASE_URL` environment variable. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] 2022/03/24
 
-* Re-implement buildpack using [libcnb.rs](https://github.com/Malax/libcnb.rs) ([#273](https://github.com/heroku/buildpacks-jvm/pull/273))
+* Re-implement buildpack using [libcnb.rs](https://github.com/heroku/libcnb.rs) ([#273](https://github.com/heroku/buildpacks-jvm/pull/273))
 * Source and Javadoc JAR files are no longer considered when determining the default web process. ([#273](https://github.com/heroku/buildpacks-jvm/pull/273))
 
 ## [0.2.6] 2022/03/02


### PR DESCRIPTION
libcnb.rs moved from:
https://github.com/Malax/libcnb.rs

...to:
https://github.com/heroku/libcnb.rs

GUS-W-11312893.