### PR TITLE
Post-release updates: heroku/jvm-function-invoker 0.6.3

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] 2022/06/29
+
 * Upgrade `libcnb` to `0.8.0` and `libherokubuildpack` to `0.8.0`.
 * Updated function runtime to `1.0.7`
 

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.6"
 
 [buildpack]
 id = "heroku/jvm-function-invoker"
-version = "0.6.3"
+version = "0.6.4"
 name = "JVM Function Invoker"
 clear-env = true
 homepage = "https://github.com/heroku/buildpacks-jvm"

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Upgraded `heroku/jvm-function-invoker` to `0.6.3`
 
 ## [0.3.31] 2022/06/09
 * Upgraded `heroku/jvm-function-invoker` to `0.6.2`

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -22,7 +22,7 @@ version = "1.0.1"
 
 [[order.group]]
 id = "heroku/jvm-function-invoker"
-version = "0.6.2"
+version = "0.6.3"
 
 [metadata]
 

--- a/meta-buildpacks/java-function/package.toml
+++ b/meta-buildpacks/java-function/package.toml
@@ -8,4 +8,4 @@ uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:dd3
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:e17eeb20348354547793da1dc85401a0556bda9129c476aa1f6c2216bab898a3"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-function-invoker-buildpack@sha256:a6348410b4f504c4d2158518409f86bfbed6902bb5ec5740f8272b29142b8ac2"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-function-invoker-buildpack@sha256:f95e93ed7056c5b46f61226fb6407ba798b82eb879aaaa29ef2e78bdf55ec6c1"

--- a/test/meta-buildpacks/java-function/buildpack.toml
+++ b/test/meta-buildpacks/java-function/buildpack.toml
@@ -17,4 +17,4 @@ version = "1.0.2"
 
 [[order.group]]
 id = "heroku/jvm-function-invoker"
-version = "0.6.3"
+version = "0.6.4"


### PR DESCRIPTION
Manually made the post release update for `heroku/jvm-function-invoker 0.6.3`

Update buildpack versions and changelogs