### PR TITLE
Post-release updates: heroku/java 0.6.1

### DIFF
--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.1] 2022/07/26
 * Upgraded `heroku/jvm` to `1.0.2`
 * Upgraded `heroku/procfile` to `1.0.2`
 

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "heroku/java"
-version = "0.6.1"
+version = "0.6.2"
 name = "Java"
 homepage = "https://github.com/heroku/buildpacks-jvm"
 description = "Official Heroku buildpack for Java applications."


### PR DESCRIPTION
Pull-request to update buildpack versions and changelogs
after releasing version `0.6.1` of `heroku/java`.

https://github.com/buildpacks/registry-index/issues/3404