### PR TITLE
Test multiple builders/stacks in integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,14 @@ jobs:
     parameters:
       spec_dir:
         type: string
+      cnb_builder:
+        type: string
     machine:
       image: ubuntu-2004:current
     resource_class: xlarge
     environment:
       PARALLEL_SPLIT_TEST_PROCESSES: 8
+      INTEGRATION_TEST_CNB_BUILDER: "<< parameters.cnb_builder >>"
     steps:
       - checkout
       - pack/install-pack:
@@ -88,8 +91,13 @@ jobs:
           command: bundle exec rspec << parameters.spec_dir >>
 
   cargo-test:
+    parameters:
+      cnb_builder:
+        type: string
     machine:
       image: ubuntu-2004:current
+    environment:
+      INTEGRATION_TEST_CNB_BUILDER: "<< parameters.cnb_builder >>"
     steps:
       - checkout
       - heroku-buildpacks/install-build-dependencies
@@ -113,7 +121,6 @@ workflows:
   ci:
     jobs:
       - shell-linting
-      - cargo-test
       - rustfmt
       - package-buildpack:
           matrix:
@@ -126,9 +133,18 @@ workflows:
                 - "meta-buildpacks/java-function"
                 - "test/meta-buildpacks/java"
                 - "test/meta-buildpacks/java-function"
+      - cargo-test:
+          matrix:
+            parameters:
+              cnb_builder:
+                - "heroku/buildpacks:20"
+                - "heroku/builder:22"
       - cutlass:
           matrix:
             parameters:
               spec_dir:
                 - "test/specs/java"
                 - "test/specs/java-function"
+              cnb_builder:
+                - "heroku/buildpacks:20"
+                - "heroku/builder:22"

--- a/buildpacks/jvm/tests/integration_tests.rs
+++ b/buildpacks/jvm/tests/integration_tests.rs
@@ -2,12 +2,18 @@ use libcnb_test::{assert_contains, BuildConfig, TestRunner};
 
 #[test]
 fn test() {
+    let builder_name = std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap();
+
     TestRunner::default().build(
-        BuildConfig::new("heroku/buildpacks:20", "../../test-fixtures/java-8-app"),
+        BuildConfig::new(&builder_name, "../../test-fixtures/java-8-app"),
         |context| {
             assert_contains!(
                 context.run_shell_command("java -version").stderr,
-                "openjdk version \"1.8.0_342-heroku\""
+                match builder_name.as_str() {
+                    "heroku/buildpacks:18" | "heroku/buildpacks:20" =>
+                        "openjdk version \"1.8.0_342-heroku\"",
+                    _ => "openjdk version \"1.8.0_342\"",
+                }
             );
         },
     )

--- a/buildpacks/maven/tests/customization_tests.rs
+++ b/buildpacks/maven/tests/customization_tests.rs
@@ -55,7 +55,7 @@ fn maven_custom_opts() {
 
 fn default_config() -> BuildConfig {
     BuildConfig::new(
-        "heroku/buildpacks:20",
+        std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap(),
         "../../test-fixtures/simple-http-service",
     )
     .buildpacks(vec![

--- a/buildpacks/maven/tests/misc_tests.rs
+++ b/buildpacks/maven/tests/misc_tests.rs
@@ -138,7 +138,7 @@ fn descriptive_error_message_on_failed_build() {
 
 fn default_config() -> BuildConfig {
     BuildConfig::new(
-        "heroku/buildpacks:20",
+        std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap(),
         "../../test-fixtures/simple-http-service",
     )
     .buildpacks(vec![

--- a/buildpacks/maven/tests/polyglot_tests.rs
+++ b/buildpacks/maven/tests/polyglot_tests.rs
@@ -4,7 +4,7 @@ use libcnb_test::{assert_contains, BuildConfig, BuildpackReference, TestRunner};
 fn polyglot_maven_app() {
     TestRunner::default().build(
         BuildConfig::new(
-            "heroku/buildpacks:20",
+            std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap(),
             "../../test-fixtures/simple-http-service-groovy-polyglot",
         )
         .buildpacks(vec![

--- a/buildpacks/maven/tests/process_types_tests.rs
+++ b/buildpacks/maven/tests/process_types_tests.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 fn spring_boot_process_type() {
     TestRunner::default().build(
         BuildConfig::new(
-            "heroku/buildpacks:20",
+            std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap(),
             "../../test-fixtures/buildpack-java-spring-boot-test",
         )
         .buildpacks(vec![

--- a/buildpacks/maven/tests/settings_xml_tests.rs
+++ b/buildpacks/maven/tests/settings_xml_tests.rs
@@ -175,7 +175,7 @@ fn maven_settings_xml_in_app_root_and_explicit_settings_url() {
 
 fn default_config() -> BuildConfig {
     BuildConfig::new(
-        "heroku/buildpacks:20",
+        std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap(),
         "../../test-fixtures/simple-http-service",
     )
     .buildpacks(vec![

--- a/buildpacks/maven/tests/version_handling_tests.rs
+++ b/buildpacks/maven/tests/version_handling_tests.rs
@@ -152,7 +152,7 @@ fn without_wrapper_and_maven_3_2_5_system_properties() {
 
 fn default_config() -> BuildConfig {
     BuildConfig::new(
-        "heroku/buildpacks:20",
+        std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap(),
         "../../test-fixtures/simple-http-service",
     )
     .buildpacks(vec![

--- a/test/specs/java-function/spec_helper.rb
+++ b/test/specs/java-function/spec_helper.rb
@@ -10,7 +10,7 @@ end
 JVM_FUNCTION_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("meta-buildpacks/java-function"))
 Cutlass.config do |config|
   config.default_buildpack_paths = [JVM_FUNCTION_BUILDPACK]
-  config.default_builder = "heroku/buildpacks:18"
+  config.default_builder = ENV["INTEGRATION_TEST_CNB_BUILDER"]
   config.default_repo_dirs = [test_dir.join("../test-fixtures")]
 end
 

--- a/test/specs/java/spec_helper.rb
+++ b/test/specs/java/spec_helper.rb
@@ -11,7 +11,7 @@ end
 JVM_BUILDPACK = Cutlass::LocalBuildpack.new(directory: test_dir.join("meta-buildpacks/java"))
 Cutlass.config do |config|
   config.default_buildpack_paths = [JVM_BUILDPACK]
-  config.default_builder = "heroku/buildpacks:18"
+  config.default_builder = ENV["INTEGRATION_TEST_CNB_BUILDER"]
   config.default_repo_dirs = [test_dir.join("../test-fixtures")]
 end
 


### PR DESCRIPTION
This PR changes the existing integration tests to use an environment variable instead of a hardcoded value to determine the builder used during testing. This allows us to set up a test matrix in CI that ensures we test all supported builders/stacks. This is also implemented in this PR.

Closes GUS-W-11300244