### PR TITLE
Update libcnb to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,22 +650,23 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libcnb"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a8206c9c5004aa37c8369e27494cdda7744611f4b39f95b5bbbbd5a9365c20"
+checksum = "4d67f6f6f7dd0a13fce25a9247fd9a0e5cbe97c8431fee0008c674602e36c9e4"
 dependencies = [
  "libcnb-data",
  "libcnb-proc-macros",
  "serde",
+ "stacker",
  "thiserror",
  "toml",
 ]
 
 [[package]]
 name = "libcnb-data"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498e6ba7cfd2520053c75d1a3f4f98f09d0e45103f043f7f8cfe422b236b8e4b"
+checksum = "52cd3749d2c63a77a4d2b069904ecb526977692352186ec3094b15df50c71ee3"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -676,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.2.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac843541f7874babc40106a52e35972931f66ca95e5adabbc8b20ca36063e5ea"
+checksum = "3e245f2e25a5fc10593db933f25e739f9c5a6d0f944c3bebac6b282e0a9888a1"
 dependencies = [
  "cargo_metadata",
  "libcnb-data",
@@ -688,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.3.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21023e1598df3f6fea1b188a34ce06ca41181f03ed3d71169ebaa58c8cfd278b"
+checksum = "f298d2d11525f72ea88e0f529372d11e62b1410c2f11a65c8eb061581597710f"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
@@ -700,14 +701,15 @@ dependencies = [
 
 [[package]]
 name = "libcnb-test"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8111541bbccb29e423bc8904f0d750793a484601fd52b177bd478af544c6f2"
+checksum = "a8987577ad4be4171cbb730e7a23be913a5a83da624a6ea9eb5457ab9a55c405"
 dependencies = [
  "bollard",
  "cargo_metadata",
  "fastrand",
  "fs_extra",
+ "libcnb-data",
  "libcnb-package",
  "serde",
  "tempfile",
@@ -717,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896572dbc018df95e8539bfdadd8da6fc5646d41c2f8cadfe31075b0ef7bc57c"
+checksum = "ea1621294a166cafb93e9df130da45d951ed26910b209d4c356684028e53b4f4"
 dependencies = [
  "flate2",
  "libcnb",
@@ -857,6 +859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f446d0a6efba22928558c4fb4ce0b3fd6c89b0061343e390bf01a703742b8125"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1061,6 +1072,19 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -4,7 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Updated `libcnb` and `libherokubuildpack` to `0.9.0`. ([#330](https://github.com/heroku/buildpacks-jvm/pull/330))
+* Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
 
 ## [0.6.3] 2022/06/29
 

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
-* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
 
 ## [0.6.3] 2022/06/29
 

--- a/buildpacks/jvm-function-invoker/Cargo.toml
+++ b/buildpacks/jvm-function-invoker/Cargo.toml
@@ -7,8 +7,8 @@ rust-version = "1.56"
 
 [dependencies]
 indoc = "1.0.7"
-libcnb = "0.9.0"
-libherokubuildpack = { version = "0.9.0", features = ["toml"] }
+libcnb = "0.10.0"
+libherokubuildpack = { version = "0.10.0", features = ["toml"] }
 serde = "1.0.144"
 thiserror = "1.0.33"
 toml = "0.5.9"

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.8"
 
 [buildpack]
 id = "heroku/jvm-function-invoker"

--- a/buildpacks/jvm-function-invoker/src/main.rs
+++ b/buildpacks/jvm-function-invoker/src/main.rs
@@ -14,7 +14,7 @@ use crate::layers::runtime::RuntimeLayer;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::buildpack_main;
 use libcnb::data::build_plan::BuildPlanBuilder;
-use libcnb::data::launch::{Launch, ProcessBuilder};
+use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
 use libcnb::data::{layer_name, process_type};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
@@ -81,11 +81,16 @@ impl Buildpack for JvmFunctionInvokerBuildpack {
 
         BuildResultBuilder::new()
             .launch(
-                Launch::new().process(
-                    ProcessBuilder::new(process_type!("web"), layers::opt::JVM_RUNTIME_SCRIPT_NAME)
+                LaunchBuilder::new()
+                    .process(
+                        ProcessBuilder::new(
+                            process_type!("web"),
+                            layers::opt::JVM_RUNTIME_SCRIPT_NAME,
+                        )
                         .default(true)
                         .build(),
-                ),
+                    )
+                    .build(),
             )
             .build()
     }

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
-* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
 
 ## [1.0.3] 2022/08/29
 

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+
 ## [1.0.3] 2022/08/29
 
 * Default version for **OpenJDK 8** is now `1.8.0_345`

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 fs_extra = "1.2.0"
 java-properties = "1.4.1"
-libcnb = "0.9.0"
-libherokubuildpack = "0.9.0"
+libcnb = "0.10.0"
+libherokubuildpack = "0.10.0"
 serde = { version = "1.0.144", features = ["derive"] }
 sha2 = "0.10.3"
 tempfile = "3.3.0"
@@ -18,4 +18,4 @@ ureq = "2.5.0"
 indoc = "1.0.7"
 
 [dev-dependencies]
-libcnb-test = "0.6.0"
+libcnb-test = "0.10.0"

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.8"
 
 [buildpack]
 id = "heroku/jvm"

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+
 ## [1.0.2] 2022/07/29
 
 * Updated `libcnb` and `libherokubuildpack` to `0.9.0`. ([#330](https://github.com/heroku/buildpacks-jvm/pull/330))

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
-* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
 
 ## [1.0.2] 2022/07/29
 

--- a/buildpacks/maven/Cargo.toml
+++ b/buildpacks/maven/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 [dependencies]
 indoc = "1.0.7"
 java-properties = "1.4.1"
-libcnb = "0.9.0"
-libherokubuildpack = "0.9.0"
+libcnb = "0.10.0"
+libherokubuildpack = "0.10.0"
 serde = { version = "1.0.144", features = ["derive"] }
 tempfile = "3.3.0"
 shell-words = "1.1.0"
 regex = "1.6.0"
 
 [dev-dependencies]
-libcnb-test = "0.6.0"
+libcnb-test = "0.10.0"
 ureq = "2.5.0"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.8"
 
 [buildpack]
 id = "heroku/maven"

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -15,7 +15,7 @@ use crate::settings::{resolve_settings_xml_path, SettingsError};
 use crate::warnings::{log_default_maven_version_warning, log_unused_maven_wrapper_warning};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::build_plan::BuildPlanBuilder;
-use libcnb::data::launch::{Launch, ProcessBuilder};
+use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
 use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
@@ -258,7 +258,8 @@ impl Buildpack for MavenBuildpack {
         if let Some(process) = framework::default_app_process(&context.app_dir)
             .map_err(MavenBuildpackError::DefaultAppProcessError)?
         {
-            build_result_builder = build_result_builder.launch(Launch::new().process(process));
+            build_result_builder =
+                build_result_builder.launch(LaunchBuilder::new().process(process).build());
         }
 
         build_result_builder.build()

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+
 ## [0.3.35] 2022/08/29
 * Upgraded `heroku/jvm` to `1.0.3`
 

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -4,7 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
 
 ## [0.3.35] 2022/08/29
 * Upgraded `heroku/jvm` to `1.0.3`

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.4"
+api = "0.8"
 
 [buildpack]
 id = "heroku/java-function"

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+
 ## [0.6.3] 2022/08/29
 * Upgraded `heroku/jvm` to `1.0.3`
 

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -4,7 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Buildpack now requires buildpack API version `0.8`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
 
 ## [0.6.3] 2022/08/29
 * Upgraded `heroku/jvm` to `1.0.3`

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.4"
+api = "0.8"
 
 [buildpack]
 id = "heroku/java"

--- a/test/meta-buildpacks/java-function/buildpack.toml
+++ b/test/meta-buildpacks/java-function/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.4"
+api = "0.8"
 
 [buildpack]
 id = "heroku/java-function-test"

--- a/test/meta-buildpacks/java/buildpack.toml
+++ b/test/meta-buildpacks/java/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.4"
+api = "0.8"
 
 [buildpack]
 id = "heroku/java-test"


### PR DESCRIPTION
Update `libcnb` and `libherokubuildpack` to `0.10.0` and therefore to buildpack API `0.8` as well.

Closes GUS-W-11680341