### PR TITLE
Update JVM function runtime to 1.1.0

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -4,8 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Upgrade `libcnb` and `libherokubuildpack` to `0.11.0`. ([#371](https://github.com/heroku/buildpacks-jvm/pull/371))
 * Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Updated function runtime to `1.1.0`
 
 ## [0.6.3] 2022/06/29
 

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -26,8 +26,8 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.0.7/sf-fx-runtime-java-runtime-1.0.7-jar-with-dependencies.jar"
-sha256 = "91b1c8c2b42dfbda6147ea32f114ae44e496a0577af7f19e31b51e619cb2962b"
+url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.1.0/sf-fx-runtime-java-runtime-1.1.0-jar-with-dependencies.jar"
+sha256 = "4377609098de2842d529aa67c2a75d5484a2a4b719fcd84e412ad084dd77040b"
 
 [metadata.release]
 

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -4,7 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
+* Upgrade `libcnb` and `libherokubuildpack` to `0.11.0`. ([#371](https://github.com/heroku/buildpacks-jvm/pull/371))
 * Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#363](https://github.com/heroku/buildpacks-jvm/pull/363))
 
 ## [1.0.2] 2022/07/29


### PR DESCRIPTION
This PR also fixes the libcnb version bump related CHANGELOG entries for buildpacks where they were wrong.