### PR TITLE
OpenJDK Q4 2022 updates

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Default version for **OpenJDK 8** is now `1.8.0_352`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
+* Default version for **OpenJDK 11** is now `11.0.17`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
+* Default version for **OpenJDK 13** is now `13.0.13`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
+* Default version for **OpenJDK 15** is now `15.0.9`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
+* Default version for **OpenJDK 17** is now `17.0.5`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
+* Default version for **OpenJDK 19** is now `19.0.1`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
+* Upgrade `libcnb` and `libherokubuildpack` to `0.11.1`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
+
 ## [1.0.4] 2022/09/28
 
 * Upgrade `libcnb` and `libherokubuildpack` to `0.11.0`. ([#371](https://github.com/heroku/buildpacks-jvm/pull/371))

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Default version for **OpenJDK 15** is now `15.0.9`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
 * Default version for **OpenJDK 17** is now `17.0.5`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
 * Default version for **OpenJDK 19** is now `19.0.1`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
-* Upgrade `libcnb` and `libherokubuildpack` to `0.11.1`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
+* Upgrade `libcnb` and `libherokubuildpack` to `0.11.1`. ([#384](https://github.com/heroku/buildpacks-jvm/pull/384) and [#386](https://github.com/heroku/buildpacks-jvm/pull/386))
 
 ## [1.0.4] 2022/09/28
 

--- a/buildpacks/jvm/src/version.rs
+++ b/buildpacks/jvm/src/version.rs
@@ -18,18 +18,18 @@ pub fn normalize_version_string<S: Into<String>>(
 
     let version_string = match user_version_string {
         "7" | "1.7" => "1.7.0_352",
-        "8" | "1.8" => "1.8.0_345",
+        "8" | "1.8" => "1.8.0_352",
         "9" | "1.9" => "9.0.4",
         "10" => "10.0.2",
-        "11" => "11.0.16.1",
+        "11" => "11.0.17",
         "12" => "12.0.2",
-        "13" => "13.0.12",
+        "13" => "13.0.13",
         "14" => "14.0.2",
-        "15" => "15.0.8",
+        "15" => "15.0.9",
         "16" => "16.0.2",
-        "17" => "17.0.4.1",
+        "17" => "17.0.5",
         "18" => "18.0.2.1",
-        "19" => "19.0.0",
+        "19" => "19.0.1",
         other => other,
     };
 
@@ -110,22 +110,22 @@ mod tests {
     fn normalize_version_string_stack_specific_distribution() {
         assert_eq!(
             normalize_version_string(&stack_id!("heroku-18"), "8"),
-            Ok((OpenJDKDistribution::Heroku, String::from("1.8.0_345")))
+            Ok((OpenJDKDistribution::Heroku, String::from("1.8.0_352")))
         );
 
         assert_eq!(
             normalize_version_string(&stack_id!("heroku-20"), "8"),
-            Ok((OpenJDKDistribution::Heroku, String::from("1.8.0_345")))
+            Ok((OpenJDKDistribution::Heroku, String::from("1.8.0_352")))
         );
 
         assert_eq!(
             normalize_version_string(&stack_id!("heroku-22"), "8"),
-            Ok((OpenJDKDistribution::AzulZulu, String::from("1.8.0_345")))
+            Ok((OpenJDKDistribution::AzulZulu, String::from("1.8.0_352")))
         );
 
         assert_eq!(
             normalize_version_string(&stack_id!("bogus"), "8"),
-            Ok((OpenJDKDistribution::AzulZulu, String::from("1.8.0_345")))
+            Ok((OpenJDKDistribution::AzulZulu, String::from("1.8.0_352")))
         );
     }
 

--- a/buildpacks/jvm/tests/integration_tests.rs
+++ b/buildpacks/jvm/tests/integration_tests.rs
@@ -11,8 +11,8 @@ fn test() {
                 context.run_shell_command("java -version").stderr,
                 match builder_name.as_str() {
                     "heroku/buildpacks:18" | "heroku/buildpacks:20" =>
-                        "openjdk version \"1.8.0_345-heroku\"",
-                    _ => "openjdk version \"1.8.0_345\"",
+                        "openjdk version \"1.8.0_352-heroku\"",
+                    _ => "openjdk version \"1.8.0_352\"",
                 }
             );
         },


### PR DESCRIPTION
* Default version for **OpenJDK 8** is now `1.8.0_352`.
* Default version for **OpenJDK 11** is now `11.0.17`.
* Default version for **OpenJDK 13** is now `13.0.13`.
* Default version for **OpenJDK 15** is now `15.0.9`.
* Default version for **OpenJDK 17** is now `17.0.5`.
* Default version for **OpenJDK 19** is now `19.0.1`. 

Also updates CHANGELOG to contain the version bumps made by @dependabot

Closes GUS-W-11930880