### PR TITLE
Add required permissions to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     name: Release ${{ github.event.inputs.requested_buildpack_id }}
     runs-on: ubuntu-20.04 # ubuntu-latest currently resolves to 18.04 which does not have aws-cli 2.x yet
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       REQUESTED_BUILDPACK_ID: ${{ github.event.inputs.requested_buildpack_id }}
     steps:


### PR DESCRIPTION
The release workflow no longer works in its current form. I suspect that the GitHub org changed the default permissions of the token minted for an GitHub action workflow is now read-only: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

Example of a failed run: https://github.com/heroku/buildpacks-jvm/actions/runs/3287988945 (See: `Resource not accessible by integration`)

This PR adds the required permission back to the `release` job so it can create releases again. It also adds the required permissions for the https://github.com/peter-evans/create-pull-request action we use to create the update PR.

Closes GUS-W-11937667