### PR TITLE
Post-release updates: heroku/jvm 1.0.5

### DIFF
--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -24,12 +24,9 @@ id = "heroku-22"
 id = "io.buildpacks.stacks.bionic"
 
 [metadata]
-
 [metadata.runtime]
 url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.1.1/sf-fx-runtime-java-runtime-1.1.1-jar-with-dependencies.jar"
 sha256 = "4f709f909e43611d23c62392dca8eafaf1b72e59bf5036bb746e17e1dde59282"
-
 [metadata.release]
-
 [metadata.release.docker]
 repository = "public.ecr.aws/heroku-buildpacks/heroku-jvm-function-invoker-buildpack"

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] 2022/10/20
+
 * Default version for **OpenJDK 8** is now `1.8.0_352`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
 * Default version for **OpenJDK 11** is now `11.0.17`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
 * Default version for **OpenJDK 13** is now `13.0.13`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "heroku/jvm"
-version = "1.0.5"
+version = "1.0.6"
 name = "Heroku OpenJDK Buildpack"
 homepage = "https://github.com/heroku/buildpacks-jvm"
 description = "Official Heroku buildpack for installing OpenJDK"
@@ -24,12 +24,9 @@ id = "heroku-22"
 id = "io.buildpacks.stacks.bionic"
 
 [metadata]
-
 [metadata.heroku-metrics-agent]
 url = "https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.14/heroku-java-metrics-agent-3.14.jar"
 sha256 = "ad28a69907fb71b64549603065e4b7259ae9356989b054f6157ef289bbbfe4b6"
-
 [metadata.release]
-
 [metadata.release.docker]
 repository = "public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -26,26 +26,19 @@ id = "*"
 
 [metadata]
 default-version = "3.6.2"
-
 [metadata.tarballs]
-
 [metadata.tarballs."3.2.5"]
 url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.2.5.tar.gz"
 sha256 = "bd37fad4863cd01524f31ada88ce9f0632040976d64561157cafc98959764341"
-
 [metadata.tarballs."3.6.2"]
 url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.6.2.tar.gz"
 sha256 = "63fe4e0bf88d5ec732736f4baa2b62172e654130e16c1db02c252c639b9fd3df"
-
 [metadata.tarballs."3.5.4"]
 url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.5.4.tar.gz"
 sha256 = "2fa7a911bfef93a3bc0699674efd307a53da28f9179a50b10d183080b1f5bbc0"
-
 [metadata.tarballs."3.3.9"]
 url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.3.9.tar.gz"
 sha256 = "72e5a073cd1acb8925a55366a37268d28a5bdde76d4cda4888364068472aa46e"
-
 [metadata.release]
-
 [metadata.release.docker]
 repository = "public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack"

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Upgraded `heroku/jvm` to `1.0.5`
 
 ## [0.3.36] 2022/09/28
 * Upgraded `heroku/maven` to `1.0.3`

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -14,7 +14,7 @@ type = "BSD-3-Clause"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.4"
+version = "1.0.5"
 
 [[order.group]]
 id = "heroku/maven"
@@ -25,8 +25,6 @@ id = "heroku/jvm-function-invoker"
 version = "0.6.4"
 
 [metadata]
-
 [metadata.release]
-
 [metadata.release.docker]
 repository = "public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack"

--- a/meta-buildpacks/java-function/package.toml
+++ b/meta-buildpacks/java-function/package.toml
@@ -2,7 +2,7 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:be15cf81510e9132f2b148cb107e1032479e02e7ad2895a7e7213fc0799c73fc"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:69ca64eb7466890c5edd199b8083f63d65bc5b25ed360c7e6edf56770f4c34c6"
 
 [[dependencies]]
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:450ccbb49d5e81bda57ab32637cf9ba53fcd47a1b0af979ea8d090ed122f1cb1"

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Upgraded `heroku/jvm` to `1.0.5`
 
 ## [0.6.4] 2022/09/28
 * Upgraded `heroku/maven` to `1.0.3`

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -15,7 +15,7 @@ type = "BSD-3-Clause"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.4"
+version = "1.0.5"
 
 [[order.group]]
 id = "heroku/maven"
@@ -27,8 +27,6 @@ version = "2.0.0"
 optional = true
 
 [metadata]
-
 [metadata.release]
-
 [metadata.release.docker]
 repository = "public.ecr.aws/heroku-buildpacks/heroku-java-buildpack"

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -2,7 +2,7 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:be15cf81510e9132f2b148cb107e1032479e02e7ad2895a7e7213fc0799c73fc"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:69ca64eb7466890c5edd199b8083f63d65bc5b25ed360c7e6edf56770f4c34c6"
 
 [[dependencies]]
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:450ccbb49d5e81bda57ab32637cf9ba53fcd47a1b0af979ea8d090ed122f1cb1"

--- a/test/meta-buildpacks/java-function/buildpack.toml
+++ b/test/meta-buildpacks/java-function/buildpack.toml
@@ -9,7 +9,7 @@ name = "Java Function"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.5"
+version = "1.0.6"
 
 [[order.group]]
 id = "heroku/maven"

--- a/test/meta-buildpacks/java/buildpack.toml
+++ b/test/meta-buildpacks/java/buildpack.toml
@@ -9,7 +9,7 @@ name = "Java"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.5"
+version = "1.0.6"
 
 [[order.group]]
 id = "heroku/maven"


### PR DESCRIPTION
Due to a failed workflow (https://github.com/heroku/buildpacks-jvm/actions/runs/3287988945), this is created by hand instead.