### PR TITLE
Update sf-fx-runtime-java from 1.1.1 to 1.1.2

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Update `sf-fx-runtime-java` from `1.1.1` to `1.1.2`. ([#398](https://github.com/heroku/buildpacks-jvm/pull/398))
 
 ## [0.6.5] 2022/10/20
 

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "heroku/jvm-function-invoker"
-version = "0.6.6"
+version = "0.6.7"
 name = "JVM Function Invoker"
 clear-env = true
 homepage = "https://github.com/heroku/buildpacks-jvm"
@@ -26,8 +26,8 @@ id = "io.buildpacks.stacks.bionic"
 [metadata]
 
 [metadata.runtime]
-url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.1.1/sf-fx-runtime-java-runtime-1.1.1-jar-with-dependencies.jar"
-sha256 = "4f709f909e43611d23c62392dca8eafaf1b72e59bf5036bb746e17e1dde59282"
+url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.1.2/sf-fx-runtime-java-runtime-1.1.2-jar-with-dependencies.jar"
+sha256 = "2db1aa68ac92c1fe4efa8a07af9511c4508bb5c8c43b1f4606b381e3a584fd0a"
 
 [metadata.release]
 


### PR DESCRIPTION
Updates buildpack to use the `1.1.2` version of the Java function invoker