### PR TITLE
Update sf-fx-runtime-java from 1.1.2 to 1.1.3

### DIFF
--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Update `sf-fx-runtime-java` from `1.1.2` to `1.1.3`.
 
 ## [0.6.6] 2022/11/30
 * Update `sf-fx-runtime-java` from `1.1.1` to `1.1.2`. ([#398](https://github.com/heroku/buildpacks-jvm/pull/398))

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -25,8 +25,8 @@ id = "io.buildpacks.stacks.bionic"
 
 [metadata]
 [metadata.runtime]
-url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.1.2/sf-fx-runtime-java-runtime-1.1.2-jar-with-dependencies.jar"
-sha256 = "2db1aa68ac92c1fe4efa8a07af9511c4508bb5c8c43b1f4606b381e3a584fd0a"
+url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.1.3/sf-fx-runtime-java-runtime-1.1.3-jar-with-dependencies.jar"
+sha256 = "b8e17b6ee9889304cbd07958f86ac067cb58c7f6bdd324a87133d377f670adb5"
 [metadata.release]
 [metadata.release.docker]
 repository = "public.ecr.aws/heroku-buildpacks/heroku-jvm-function-invoker-buildpack"


### PR DESCRIPTION
Updates buildpack to use the `1.1.3` version of the Java function invoker

Includes changes:
* https://github.com/forcedotcom/sf-fx-runtime-java/compare/1.1.2...1.1.3