### PR TITLE
Use `pub(crate)` instead of `pub` in buildpacks

### DIFF
--- a/buildpacks/jvm-function-invoker/src/common.rs
+++ b/buildpacks/jvm-function-invoker/src/common.rs
@@ -2,7 +2,7 @@ use libcnb::read_toml_file;
 use libherokubuildpack::toml::toml_select_value;
 use std::path::Path;
 
-pub fn project_toml_salesforce_type_is_function(project_toml_path: &Path) -> bool {
+pub(crate) fn project_toml_salesforce_type_is_function(project_toml_path: &Path) -> bool {
     read_toml_file(project_toml_path)
         .ok()
         .and_then(|table| {

--- a/buildpacks/jvm-function-invoker/src/error.rs
+++ b/buildpacks/jvm-function-invoker/src/error.rs
@@ -1,5 +1,5 @@
 use indoc::{formatdoc, indoc};
-use libcnb::{Error, TomlFileError};
+use libcnb::Error;
 
 use crate::layers::bundle::BundleLayerError;
 use crate::layers::opt::OptLayerError;
@@ -16,9 +16,6 @@ pub(crate) enum JvmFunctionInvokerBuildpackError {
 
     #[error("Bundle layer error: {0}")]
     BundleLayerError(#[from] BundleLayerError),
-
-    #[error("Could not write launch.toml: {0}")]
-    CouldNotWriteLaunchToml(TomlFileError),
 }
 
 impl From<JvmFunctionInvokerBuildpackError> for Error<JvmFunctionInvokerBuildpackError> {
@@ -115,11 +112,5 @@ pub(crate) fn handle_buildpack_error(error: JvmFunctionInvokerBuildpackError) {
                 "},
             ),
         },
-        JvmFunctionInvokerBuildpackError::CouldNotWriteLaunchToml(toml_error) => log_error(
-            "Could not write launch.toml",
-            formatdoc! {"
-                        Could not not write launch.toml: {toml_error}
-                    ", toml_error = toml_error},
-        ),
     };
 }

--- a/buildpacks/jvm-function-invoker/src/error.rs
+++ b/buildpacks/jvm-function-invoker/src/error.rs
@@ -7,7 +7,7 @@ use crate::layers::runtime::RuntimeLayerError;
 use libherokubuildpack::log::log_error;
 
 #[derive(thiserror::Error, Debug)]
-pub enum JvmFunctionInvokerBuildpackError {
+pub(crate) enum JvmFunctionInvokerBuildpackError {
     #[error("Opt layer error: {0}")]
     OptLayerError(#[from] OptLayerError),
 
@@ -27,7 +27,7 @@ impl From<JvmFunctionInvokerBuildpackError> for Error<JvmFunctionInvokerBuildpac
     }
 }
 
-pub fn handle_buildpack_error(error: JvmFunctionInvokerBuildpackError) {
+pub(crate) fn handle_buildpack_error(error: JvmFunctionInvokerBuildpackError) {
     match error {
         JvmFunctionInvokerBuildpackError::OptLayerError(inner) => match inner {
             OptLayerError::CouldNotWriteRuntimeScript(io_error)

--- a/buildpacks/jvm-function-invoker/src/layers/bundle.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/bundle.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 use std::process::Command;
 use thiserror::Error;
 
-pub struct BundleLayer {
-    pub env: Env,
+pub(crate) struct BundleLayer {
+    pub(crate) env: Env,
 }
 
 impl Layer for BundleLayer {
@@ -109,7 +109,7 @@ fn log_function_metadata(bundle_dir: impl AsRef<Path>) -> Result<(), BundleLayer
 }
 
 #[derive(Error, Debug)]
-pub enum BundleLayerError {
+pub(crate) enum BundleLayerError {
     #[error("Project does not contain any valid functions")]
     NoFunctionsFound,
     #[error("Project contains multiple functions")]
@@ -126,4 +126,4 @@ pub enum BundleLayerError {
     CouldNotReadFunctionBundleToml(TomlFileError),
 }
 
-pub const FUNCTION_BUNDLE_DIR_ENV_VAR_NAME: &str = "JVM_FUNCTION_BUNDLE_DIR";
+pub(crate) const FUNCTION_BUNDLE_DIR_ENV_VAR_NAME: &str = "JVM_FUNCTION_BUNDLE_DIR";

--- a/buildpacks/jvm-function-invoker/src/layers/mod.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/mod.rs
@@ -1,3 +1,3 @@
-pub mod bundle;
-pub mod opt;
-pub mod runtime;
+pub(crate) mod bundle;
+pub(crate) mod opt;
+pub(crate) mod runtime;

--- a/buildpacks/jvm-function-invoker/src/layers/opt.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/opt.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use crate::error::JvmFunctionInvokerBuildpackError;
 use crate::JvmFunctionInvokerBuildpack;
 
-pub struct OptLayer;
+pub(crate) struct OptLayer;
 
 impl Layer for OptLayer {
     type Buildpack = JvmFunctionInvokerBuildpack;
@@ -45,11 +45,11 @@ impl Layer for OptLayer {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum OptLayerError {
+pub(crate) enum OptLayerError {
     #[error("Could not write runtime script to layer: {0}")]
     CouldNotWriteRuntimeScript(std::io::Error),
     #[error("Could not set executable bit on runtime script: {0}")]
     CouldNotSetExecutableBitForRuntimeScript(std::io::Error),
 }
 
-pub const JVM_RUNTIME_SCRIPT_NAME: &str = "jvm-runtime.sh";
+pub(crate) const JVM_RUNTIME_SCRIPT_NAME: &str = "jvm-runtime.sh";

--- a/buildpacks/jvm-function-invoker/src/layers/runtime.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/runtime.rs
@@ -11,10 +11,10 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use thiserror::Error;
 
-pub struct RuntimeLayer;
+pub(crate) struct RuntimeLayer;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RuntimeLayerMetadata {
+pub(crate) struct RuntimeLayerMetadata {
     installed_runtime_sha256: String,
 }
 
@@ -87,7 +87,7 @@ impl Layer for RuntimeLayer {
 }
 
 #[derive(Error, Debug)]
-pub enum RuntimeLayerError {
+pub(crate) enum RuntimeLayerError {
     #[error("Could not download runtime JAR: {0}")]
     DownloadFailed(DownloadError),
 
@@ -98,4 +98,4 @@ pub enum RuntimeLayerError {
     ChecksumMismatch(String),
 }
 
-pub const RUNTIME_JAR_PATH_ENV_VAR_NAME: &str = "JVM_FUNCTION_RUNTIME_JAR_PATH";
+pub(crate) const RUNTIME_JAR_PATH_ENV_VAR_NAME: &str = "JVM_FUNCTION_RUNTIME_JAR_PATH";

--- a/buildpacks/jvm-function-invoker/src/main.rs
+++ b/buildpacks/jvm-function-invoker/src/main.rs
@@ -5,6 +5,7 @@
 #![warn(clippy::pedantic)]
 // Re-disable pedantic lints that are too noisy/unwanted.
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::enum_variant_names)]
 
 use crate::common::project_toml_salesforce_type_is_function;
 use crate::error::{handle_buildpack_error, JvmFunctionInvokerBuildpackError};

--- a/buildpacks/jvm-function-invoker/src/main.rs
+++ b/buildpacks/jvm-function-invoker/src/main.rs
@@ -28,15 +28,15 @@ mod common;
 mod error;
 mod layers;
 
-pub struct JvmFunctionInvokerBuildpack;
+pub(crate) struct JvmFunctionInvokerBuildpack;
 
 #[derive(Deserialize, Debug)]
-pub struct JvmFunctionInvokerBuildpackMetadata {
+pub(crate) struct JvmFunctionInvokerBuildpackMetadata {
     runtime: JvmFunctionInvokerBuildpackRuntimeMetadata,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct JvmFunctionInvokerBuildpackRuntimeMetadata {
+pub(crate) struct JvmFunctionInvokerBuildpackRuntimeMetadata {
     url: String,
     sha256: String,
 }

--- a/buildpacks/jvm/src/bin/heroku_database_env_var_rewrite.rs
+++ b/buildpacks/jvm/src/bin/heroku_database_env_var_rewrite.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use url::Url;
 
 #[allow(clippy::missing_panics_doc)]
-pub fn main() {
+pub(crate) fn main() {
     write_exec_d_program_output(
         jvm_env_vars_for_env(&std::env::vars().collect())
             .into_iter()

--- a/buildpacks/jvm/src/bin/heroku_metrics_agent_setup.rs
+++ b/buildpacks/jvm/src/bin/heroku_metrics_agent_setup.rs
@@ -10,7 +10,7 @@ use libcnb::exec_d::write_exec_d_program_output;
 use libcnb::Env;
 use std::collections::HashMap;
 
-pub fn main() {
+pub(crate) fn main() {
     write_exec_d_program_output(output_from_env(&Env::from_current()));
 }
 

--- a/buildpacks/jvm/src/constants.rs
+++ b/buildpacks/jvm/src/constants.rs
@@ -1,3 +1,3 @@
-pub const JAVA_TOOL_OPTIONS_ENV_VAR_DELIMITER: &str = " ";
-pub const JAVA_TOOL_OPTIONS_ENV_VAR_NAME: &str = "JAVA_TOOL_OPTIONS";
-pub const JDK_OVERLAY_DIR_NAME: &str = ".jdk_overlay";
+pub(crate) const JAVA_TOOL_OPTIONS_ENV_VAR_DELIMITER: &str = " ";
+pub(crate) const JAVA_TOOL_OPTIONS_ENV_VAR_NAME: &str = "JAVA_TOOL_OPTIONS";
+pub(crate) const JDK_OVERLAY_DIR_NAME: &str = ".jdk_overlay";

--- a/buildpacks/jvm/src/errors.rs
+++ b/buildpacks/jvm/src/errors.rs
@@ -7,7 +7,7 @@ use libherokubuildpack::log::log_error;
 use std::fmt::Debug;
 
 #[allow(clippy::too_many_lines)]
-pub fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
+pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
     match error {
         // This mimics the classic behaviour of using download errors as indication for unsupported
         // versions. We want to move off of this mechanism by maintaining a static list of supported

--- a/buildpacks/jvm/src/layers/heroku_metrics_agent.rs
+++ b/buildpacks/jvm/src/layers/heroku_metrics_agent.rs
@@ -9,10 +9,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::path::Path;
 
-pub struct HerokuMetricsAgentLayer;
+pub(crate) struct HerokuMetricsAgentLayer;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct HerokuMetricsAgentLayerMetadata {
+pub(crate) struct HerokuMetricsAgentLayerMetadata {
     source: HerokuMetricsAgentMetadata,
 }
 

--- a/buildpacks/jvm/src/layers/mod.rs
+++ b/buildpacks/jvm/src/layers/mod.rs
@@ -1,3 +1,3 @@
-pub mod heroku_metrics_agent;
-pub mod openjdk;
-pub mod runtime;
+pub(crate) mod heroku_metrics_agent;
+pub(crate) mod openjdk;
+pub(crate) mod runtime;

--- a/buildpacks/jvm/src/layers/openjdk.rs
+++ b/buildpacks/jvm/src/layers/openjdk.rs
@@ -14,12 +14,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 
-pub struct OpenJdkLayer {
-    pub tarball_url: String,
+pub(crate) struct OpenJdkLayer {
+    pub(crate) tarball_url: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct OpenJdkLayerMetadata {
+pub(crate) struct OpenJdkLayerMetadata {
     jdk_overlay_applied: bool,
     source_tarball_url: String,
 }

--- a/buildpacks/jvm/src/layers/runtime.rs
+++ b/buildpacks/jvm/src/layers/runtime.rs
@@ -6,7 +6,7 @@ use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libcnb::{additional_buildpack_binary_path, Buildpack};
 use std::path::Path;
 
-pub struct RuntimeLayer;
+pub(crate) struct RuntimeLayer;
 
 impl Layer for RuntimeLayer {
     type Buildpack = OpenJdkBuildpack;

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -16,7 +16,9 @@ use crate::layers::openjdk::OpenJdkLayer;
 use crate::layers::runtime::RuntimeLayer;
 use crate::util::ValidateSha256Error;
 use crate::version::{NormalizeVersionStringError, ReadVersionStringError};
-pub(crate) use constants::*;
+pub(crate) use constants::{
+    JAVA_TOOL_OPTIONS_ENV_VAR_DELIMITER, JAVA_TOOL_OPTIONS_ENV_VAR_NAME, JDK_OVERLAY_DIR_NAME,
+};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::buildpack_main;
 use libcnb::data::build_plan::BuildPlanBuilder;

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -16,7 +16,7 @@ use crate::layers::openjdk::OpenJdkLayer;
 use crate::layers::runtime::RuntimeLayer;
 use crate::util::ValidateSha256Error;
 use crate::version::{NormalizeVersionStringError, ReadVersionStringError};
-pub use constants::*;
+pub(crate) use constants::*;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::buildpack_main;
 use libcnb::data::build_plan::BuildPlanBuilder;
@@ -27,10 +27,10 @@ use libcnb::Buildpack;
 use libherokubuildpack::download::DownloadError;
 use serde::{Deserialize, Serialize};
 
-pub struct OpenJdkBuildpack;
+pub(crate) struct OpenJdkBuildpack;
 
 #[derive(Debug)]
-pub enum OpenJdkBuildpackError {
+pub(crate) enum OpenJdkBuildpackError {
     OpenJdkDownloadError(DownloadError),
     MetricsAgentDownloadError(DownloadError),
     MetricsAgentSha256ValidationError(ValidateSha256Error),
@@ -94,13 +94,13 @@ impl Buildpack for OpenJdkBuildpack {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct OpenJdkBuildpackMetadata {
+pub(crate) struct OpenJdkBuildpackMetadata {
     #[serde(rename = "heroku-metrics-agent")]
     heroku_metrics_agent: HerokuMetricsAgentMetadata,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct HerokuMetricsAgentMetadata {
+pub(crate) struct HerokuMetricsAgentMetadata {
     url: String,
     sha256: String,
 }

--- a/buildpacks/jvm/src/util.rs
+++ b/buildpacks/jvm/src/util.rs
@@ -2,7 +2,7 @@ use std::fs::DirEntry;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
-pub enum ValidateSha256Error {
+pub(crate) enum ValidateSha256Error {
     CouldNotObtainSha256(std::io::Error),
     InvalidChecksum { actual: String, expected: String },
 }
@@ -27,7 +27,7 @@ pub(crate) fn validate_sha256<P: AsRef<Path>, S: Into<String>>(
         })
 }
 
-pub fn list_directory_contents<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<PathBuf>> {
+pub(crate) fn list_directory_contents<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<PathBuf>> {
     std::fs::read_dir(path.as_ref())
         .and_then(Iterator::collect::<std::io::Result<Vec<DirEntry>>>)
         .map(|dir_entries| dir_entries.iter().map(DirEntry::path).collect())

--- a/buildpacks/jvm/src/version.rs
+++ b/buildpacks/jvm/src/version.rs
@@ -2,7 +2,7 @@ use libcnb::data::buildpack::StackId;
 use std::fs::File;
 use std::path::Path;
 
-pub fn normalize_version_string<S: Into<String>>(
+pub(crate) fn normalize_version_string<S: Into<String>>(
     stack_id: &StackId,
     user_version_string: S,
 ) -> Result<(OpenJDKDistribution, String), NormalizeVersionStringError> {
@@ -52,11 +52,11 @@ fn default_distribution(stack_id: &StackId) -> OpenJDKDistribution {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub enum NormalizeVersionStringError {
+pub(crate) enum NormalizeVersionStringError {
     UnknownDistribution(String),
 }
 
-pub fn resolve_openjdk_url<V: Into<String>>(
+pub(crate) fn resolve_openjdk_url<V: Into<String>>(
     stack_id: &StackId,
     distribution: OpenJDKDistribution,
     version_string: V,
@@ -73,12 +73,12 @@ pub fn resolve_openjdk_url<V: Into<String>>(
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum OpenJDKDistribution {
+pub(crate) enum OpenJDKDistribution {
     Heroku,
     AzulZulu,
 }
 
-pub fn read_version_string_from_app_dir<P: AsRef<Path>>(
+pub(crate) fn read_version_string_from_app_dir<P: AsRef<Path>>(
     app_dir: P,
 ) -> Result<Option<String>, ReadVersionStringError> {
     let system_properties_path = app_dir.as_ref().join("system.properties");
@@ -96,7 +96,7 @@ pub fn read_version_string_from_app_dir<P: AsRef<Path>>(
 }
 
 #[derive(Debug)]
-pub enum ReadVersionStringError {
+pub(crate) enum ReadVersionStringError {
     CannotReadSystemProperties(std::io::Error),
     InvalidPropertiesFile(java_properties::PropertiesError),
 }

--- a/buildpacks/maven/src/errors.rs
+++ b/buildpacks/maven/src/errors.rs
@@ -4,7 +4,7 @@ use libherokubuildpack::log::log_error;
 use std::fmt::Debug;
 
 #[allow(clippy::too_many_lines)]
-pub fn on_error_maven_buildpack(error: MavenBuildpackError) {
+pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
     match error {
         MavenBuildpackError::DetermineModeError(SystemPropertiesError::IoError(error)) => log_please_try_again_error(
             "Unexpected IO error",

--- a/buildpacks/maven/src/framework.rs
+++ b/buildpacks/maven/src/framework.rs
@@ -4,12 +4,12 @@ use libcnb::data::process_type;
 use std::path::Path;
 
 #[derive(Copy, Clone)]
-pub enum Framework {
+pub(crate) enum Framework {
     SpringBoot,
     WildflySwarm,
 }
 
-pub fn detect_framework<P: AsRef<Path>>(
+pub(crate) fn detect_framework<P: AsRef<Path>>(
     app_dir: P,
 ) -> Result<Option<Framework>, DetectFrameworkError> {
     let dependency_list_string =
@@ -36,7 +36,7 @@ pub fn detect_framework<P: AsRef<Path>>(
     Ok(framework)
 }
 
-pub fn default_app_process<P: AsRef<Path>>(
+pub(crate) fn default_app_process<P: AsRef<Path>>(
     app_dir: P,
 ) -> Result<Option<Process>, DefaultAppProcessError> {
     let framework =
@@ -93,13 +93,13 @@ pub fn default_app_process<P: AsRef<Path>>(
 }
 
 #[derive(Debug)]
-pub enum DefaultAppProcessError {
+pub(crate) enum DefaultAppProcessError {
     DetectFrameworkError(DetectFrameworkError),
     IoError(std::io::Error),
 }
 
 #[derive(Debug)]
-pub enum DetectFrameworkError {
+pub(crate) enum DetectFrameworkError {
     IoError(std::io::Error),
     RegexError(regex::Error),
 }

--- a/buildpacks/maven/src/layer/maven.rs
+++ b/buildpacks/maven/src/layer/maven.rs
@@ -8,12 +8,12 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::path::Path;
 
-pub struct MavenLayer {
-    pub tarball: Tarball,
+pub(crate) struct MavenLayer {
+    pub(crate) tarball: Tarball,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MavenLayerMetadata {
+pub(crate) struct MavenLayerMetadata {
     tarball: Tarball,
 }
 

--- a/buildpacks/maven/src/layer/maven_repo.rs
+++ b/buildpacks/maven/src/layer/maven_repo.rs
@@ -7,7 +7,7 @@ use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::Buildpack;
 use std::path::Path;
 
-pub struct MavenRepositoryLayer;
+pub(crate) struct MavenRepositoryLayer;
 
 impl Layer for MavenRepositoryLayer {
     type Buildpack = MavenBuildpack;

--- a/buildpacks/maven/src/layer/mod.rs
+++ b/buildpacks/maven/src/layer/mod.rs
@@ -1,2 +1,2 @@
-pub mod maven;
-pub mod maven_repo;
+pub(crate) mod maven;
+pub(crate) mod maven_repo;

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -37,10 +37,10 @@ mod settings;
 mod util;
 mod warnings;
 
-pub struct MavenBuildpack;
+pub(crate) struct MavenBuildpack;
 
 #[derive(Debug)]
-pub enum MavenBuildpackError {
+pub(crate) enum MavenBuildpackError {
     UnsupportedMavenVersion(String),
     MavenTarballDownloadError(DownloadError),
     MavenTarballSha256IoError(std::io::Error),
@@ -61,14 +61,14 @@ pub enum MavenBuildpackError {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct MavenBuildpackMetadata {
+pub(crate) struct MavenBuildpackMetadata {
     #[serde(rename = "default-version")]
     default_version: String,
     tarballs: HashMap<String, Tarball>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Tarball {
+pub(crate) struct Tarball {
     url: String,
     sha256: String,
 }
@@ -278,7 +278,7 @@ impl From<MavenBuildpackError> for libcnb::Error<MavenBuildpackError> {
     }
 }
 
-pub fn app_dependency_list_path<P: AsRef<Path>>(app_dir: P) -> PathBuf {
+pub(crate) fn app_dependency_list_path<P: AsRef<Path>>(app_dir: P) -> PathBuf {
     app_dir.as_ref().join("target/mvn-dependency-list.log")
 }
 

--- a/buildpacks/maven/src/mode.rs
+++ b/buildpacks/maven/src/mode.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::path::Path;
 
 #[derive(Debug)]
-pub enum Mode {
+pub(crate) enum Mode {
     UseWrapper,
     InstallVersion {
         version: String,
@@ -11,7 +11,7 @@ pub enum Mode {
     },
 }
 
-pub fn determine_mode<P: AsRef<Path>, S: Into<String>>(
+pub(crate) fn determine_mode<P: AsRef<Path>, S: Into<String>>(
     app_dir: P,
     default_version: S,
 ) -> Result<Mode, SystemPropertiesError> {
@@ -59,7 +59,7 @@ fn app_configured_maven_version<P: AsRef<Path>>(
 }
 
 #[derive(Debug)]
-pub enum SystemPropertiesError {
+pub(crate) enum SystemPropertiesError {
     IoError(std::io::Error),
     PropertiesError(java_properties::PropertiesError),
 }

--- a/buildpacks/maven/src/settings.rs
+++ b/buildpacks/maven/src/settings.rs
@@ -3,7 +3,7 @@ use libherokubuildpack::download::DownloadError;
 use std::env::temp_dir;
 use std::path::{Path, PathBuf};
 
-pub fn resolve_settings_xml_path<P: AsRef<Path>>(
+pub(crate) fn resolve_settings_xml_path<P: AsRef<Path>>(
     app_dir: P,
     env: &Env,
 ) -> Result<Option<PathBuf>, SettingsError> {
@@ -14,7 +14,7 @@ pub fn resolve_settings_xml_path<P: AsRef<Path>>(
 }
 
 #[derive(Debug)]
-pub enum SettingsError {
+pub(crate) enum SettingsError {
     InvalidMavenSettingsPath(PathBuf),
     DownloadError(String, DownloadError),
 }

--- a/buildpacks/maven/src/util.rs
+++ b/buildpacks/maven/src/util.rs
@@ -2,7 +2,7 @@ use std::fs::DirEntry;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
-pub fn move_directory_contents<P: AsRef<Path>, Q: AsRef<Path>>(
+pub(crate) fn move_directory_contents<P: AsRef<Path>, Q: AsRef<Path>>(
     from: P,
     to: Q,
 ) -> std::io::Result<()> {
@@ -18,13 +18,13 @@ pub fn move_directory_contents<P: AsRef<Path>, Q: AsRef<Path>>(
     Ok(())
 }
 
-pub fn list_directory_contents<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<PathBuf>> {
+pub(crate) fn list_directory_contents<P: AsRef<Path>>(path: P) -> std::io::Result<Vec<PathBuf>> {
     std::fs::read_dir(path.as_ref())
         .and_then(Iterator::collect::<std::io::Result<Vec<DirEntry>>>)
         .map(|dir_entries| dir_entries.iter().map(DirEntry::path).collect())
 }
 
-pub fn run_command<E, F: FnOnce(std::io::Error) -> E, F2: FnOnce(ExitStatus) -> E>(
+pub(crate) fn run_command<E, F: FnOnce(std::io::Error) -> E, F2: FnOnce(ExitStatus) -> E>(
     command: &mut Command,
     io_error_fn: F,
     exit_status_fn: F2,

--- a/buildpacks/maven/src/warnings.rs
+++ b/buildpacks/maven/src/warnings.rs
@@ -1,7 +1,7 @@
 use indoc::formatdoc;
 use libherokubuildpack::log::log_warning;
 
-pub fn log_unused_maven_wrapper_warning(version: &str) {
+pub(crate) fn log_unused_maven_wrapper_warning(version: &str) {
     log_warning(
         "Unused Maven wrapper",
         formatdoc! {"
@@ -12,7 +12,7 @@ pub fn log_unused_maven_wrapper_warning(version: &str) {
     );
 }
 
-pub fn log_default_maven_version_warning(version: &str) {
+pub(crate) fn log_default_maven_version_warning(version: &str) {
     log_warning(
         "Using default version",
         formatdoc! {"


### PR DESCRIPTION
This allows clippy to detect i.e. unused variants. Fixes #403.