### PR TITLE
Post-release updates: heroku/jvm 1.0.7

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7] 2023/03/23
+
 ### Added
 
 * Support for Java 20. ([#437](https://github.com/heroku/buildpacks-jvm/pull/437))

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "heroku/jvm"
-version = "1.0.7"
+version = "1.0.8"
 name = "Heroku OpenJDK Buildpack"
 homepage = "https://github.com/heroku/buildpacks-jvm"
 description = "Official Heroku buildpack for installing OpenJDK"

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Upgraded `heroku/jvm` to `1.0.7`
 
 ## [0.3.40] 2023/01/19
 * Upgraded `heroku/jvm-function-invoker` to `0.6.7`

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -14,7 +14,7 @@ type = "BSD-3-Clause"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.6"
+version = "1.0.7"
 
 [[order.group]]
 id = "heroku/maven"

--- a/meta-buildpacks/java-function/package.toml
+++ b/meta-buildpacks/java-function/package.toml
@@ -2,7 +2,7 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:bc58cd36e77a1b16709218782fd865df63d3f3c2d25785c8e4a36b381c83a435"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:4205f979d382faf466b8c7edfe93db62eb794071f3f52382368dad58d85405ea"
 
 [[dependencies]]
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:450ccbb49d5e81bda57ab32637cf9ba53fcd47a1b0af979ea8d090ed122f1cb1"

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Upgraded `heroku/jvm` to `1.0.7`
 
 ## [0.6.6] 2023/01/18
 * Upgraded `heroku/jvm` to `1.0.6`

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -15,7 +15,7 @@ type = "BSD-3-Clause"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.6"
+version = "1.0.7"
 
 [[order.group]]
 id = "heroku/maven"

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -2,7 +2,7 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:bc58cd36e77a1b16709218782fd865df63d3f3c2d25785c8e4a36b381c83a435"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:4205f979d382faf466b8c7edfe93db62eb794071f3f52382368dad58d85405ea"
 
 [[dependencies]]
 uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:450ccbb49d5e81bda57ab32637cf9ba53fcd47a1b0af979ea8d090ed122f1cb1"

--- a/test/meta-buildpacks/java-function/buildpack.toml
+++ b/test/meta-buildpacks/java-function/buildpack.toml
@@ -9,7 +9,7 @@ name = "Java Function"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.7"
+version = "1.0.8"
 
 [[order.group]]
 id = "heroku/maven"

--- a/test/meta-buildpacks/java/buildpack.toml
+++ b/test/meta-buildpacks/java/buildpack.toml
@@ -9,7 +9,7 @@ name = "Java"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.7"
+version = "1.0.8"
 
 [[order.group]]
 id = "heroku/maven"


### PR DESCRIPTION
Since [the automation failed](https://github.com/heroku/buildpacks-jvm/actions/runs/4499126562/jobs/7920964785), this PR adds the changes by hand.