### PR TITLE
Bump undertow-core version in tests to silence security scanners

### DIFF
--- a/buildpacks/maven/tests/customization_tests.rs
+++ b/buildpacks/maven/tests/customization_tests.rs
@@ -16,13 +16,13 @@ fn maven_custom_goals() {
             indoc! {"
 
                 The following files have been resolved:
-                   io.undertow:undertow-core:jar:2.2.15.Final:compile
-                   org.jboss.logging:jboss-logging:jar:3.4.1.Final:compile
-                   org.jboss.xnio:xnio-api:jar:3.8.6.Final:compile
+                   io.undertow:undertow-core:jar:2.3.5.Final:compile
+                   org.jboss.logging:jboss-logging:jar:3.4.3.Final:compile
+                   org.jboss.xnio:xnio-api:jar:3.8.8.Final:compile
                    org.wildfly.common:wildfly-common:jar:1.5.4.Final:compile
                    org.wildfly.client:wildfly-client-config:jar:1.0.1.Final:compile
-                   org.jboss.xnio:xnio-nio:jar:3.8.6.Final:runtime
-                   org.jboss.threads:jboss-threads:jar:3.1.0.Final:compile
+                   org.jboss.xnio:xnio-nio:jar:3.8.8.Final:runtime
+                   org.jboss.threads:jboss-threads:jar:3.5.0.Final:compile
                    com.google.guava:guava:jar:30.0-jre:compile
                    com.google.guava:failureaccess:jar:1.0.1:compile
                    com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile

--- a/buildpacks/maven/tests/misc_tests.rs
+++ b/buildpacks/maven/tests/misc_tests.rs
@@ -67,6 +67,7 @@ fn no_unexpected_files_in_app_dir() {
                 /workspace/pom.xml
                 /workspace/src/main/java/com/heroku/App.java
                 /workspace/src/test/java/com/heroku/AppTest.java
+                /workspace/system.properties
                 /workspace/target/classes/com/heroku/App$1.class
                 /workspace/target/classes/com/heroku/App.class
                 /workspace/target/dependency/checker-qual-3.5.0.jar
@@ -80,7 +81,7 @@ fn no_unexpected_files_in_app_dir() {
                 /workspace/target/dependency/jsr305-3.0.2.jar
                 /workspace/target/dependency/junit-4.13.1.jar
                 /workspace/target/dependency/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-                /workspace/target/dependency/undertow-core-2.2.15.Final.jar
+                /workspace/target/dependency/undertow-core-2.3.5.Final.jar
                 /workspace/target/dependency/wildfly-client-config-1.0.1.Final.jar
                 /workspace/target/dependency/wildfly-common-1.5.4.Final.jar
                 /workspace/target/dependency/xnio-api-3.8.8.Final.jar

--- a/buildpacks/maven/tests/misc_tests.rs
+++ b/buildpacks/maven/tests/misc_tests.rs
@@ -29,13 +29,13 @@ fn mvn_dependency_list() {
             indoc! {"
 
                 The following files have been resolved:
-                   io.undertow:undertow-core:jar:2.2.15.Final:compile
-                   org.jboss.logging:jboss-logging:jar:3.4.1.Final:compile
-                   org.jboss.xnio:xnio-api:jar:3.8.6.Final:compile
+                   io.undertow:undertow-core:jar:2.3.5.Final:compile
+                   org.jboss.logging:jboss-logging:jar:3.4.3.Final:compile
+                   org.jboss.xnio:xnio-api:jar:3.8.8.Final:compile
                    org.wildfly.common:wildfly-common:jar:1.5.4.Final:compile
                    org.wildfly.client:wildfly-client-config:jar:1.0.1.Final:compile
-                   org.jboss.xnio:xnio-nio:jar:3.8.6.Final:runtime
-                   org.jboss.threads:jboss-threads:jar:3.1.0.Final:compile
+                   org.jboss.xnio:xnio-nio:jar:3.8.8.Final:runtime
+                   org.jboss.threads:jboss-threads:jar:3.5.0.Final:compile
                    com.google.guava:guava:jar:30.0-jre:compile
                    com.google.guava:failureaccess:jar:1.0.1:compile
                    com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
@@ -75,16 +75,16 @@ fn no_unexpected_files_in_app_dir() {
                 /workspace/target/dependency/guava-30.0-jre.jar
                 /workspace/target/dependency/hamcrest-core-1.3.jar
                 /workspace/target/dependency/j2objc-annotations-1.3.jar
-                /workspace/target/dependency/jboss-logging-3.4.1.Final.jar
-                /workspace/target/dependency/jboss-threads-3.1.0.Final.jar
+                /workspace/target/dependency/jboss-logging-3.4.3.Final.jar
+                /workspace/target/dependency/jboss-threads-3.5.0.Final.jar
                 /workspace/target/dependency/jsr305-3.0.2.jar
                 /workspace/target/dependency/junit-4.13.1.jar
                 /workspace/target/dependency/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
                 /workspace/target/dependency/undertow-core-2.2.15.Final.jar
                 /workspace/target/dependency/wildfly-client-config-1.0.1.Final.jar
                 /workspace/target/dependency/wildfly-common-1.5.4.Final.jar
-                /workspace/target/dependency/xnio-api-3.8.6.Final.jar
-                /workspace/target/dependency/xnio-nio-3.8.6.Final.jar
+                /workspace/target/dependency/xnio-api-3.8.8.Final.jar
+                /workspace/target/dependency/xnio-nio-3.8.8.Final.jar
                 /workspace/target/maven-archiver/pom.properties
                 /workspace/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
                 /workspace/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst

--- a/test-fixtures/simple-http-service/pom.xml
+++ b/test-fixtures/simple-http-service/pom.xml
@@ -14,8 +14,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/test-fixtures/simple-http-service/pom.xml
+++ b/test-fixtures/simple-http-service/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
-      <version>2.2.15.Final</version>
+      <version>2.3.5.Final</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/test-fixtures/simple-http-service/system.properties
+++ b/test-fixtures/simple-http-service/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
The currently used undertow version we use in one of the test fixtures has a security vulnerability. This shouldn't cause problems for the buildpack and its users, but out of an abundance of caution and to make security scanner notifications go away, this PR bumps the undertow version.

Closes GUS-W-12775352