### PR TITLE
Update Heroku JVM metrics agent to `4.0.1`

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Update [Heroku JVM metrics agent](https://github.com/heroku/heroku-java-metrics-agent) to the most recent version, `4.0.1`. This is a backwards compatible version bump. ([#445](https://github.com/heroku/buildpacks-jvm/pull/445))
+
 ## [1.0.7] 2023/03/23
 
 ### Added

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -25,8 +25,8 @@ id = "io.buildpacks.stacks.bionic"
 
 [metadata]
 [metadata.heroku-metrics-agent]
-url = "https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.14/heroku-java-metrics-agent-3.14.jar"
-sha256 = "ad28a69907fb71b64549603065e4b7259ae9356989b054f6157ef289bbbfe4b6"
+url = "https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/4.0.1/heroku-java-metrics-agent-4.0.1.jar"
+sha256 = "9a718680e4a93f93a8755b20fb21cc541e5c2692acc9da27c667530f48a716db"
 [metadata.release]
 [metadata.release.docker]
 repository = "public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack"


### PR DESCRIPTION
Update [Heroku JVM metrics agent](https://github.com/heroku/heroku-java-metrics-agent) to the most recent version, `4.0.1`. This is a backwards compatible version bump.

Ref: GUS-W-12775483