### PR TITLE
Add crate for common code between JVM buildpacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "buildpack-heroku-jvm"
+version = "0.0.0"
+dependencies = [
+ "buildpacks-jvm-shared",
+ "fs_extra",
+ "indoc",
+ "java-properties",
+ "libcnb",
+ "libcnb-test",
+ "libherokubuildpack",
+ "serde",
+ "sha2",
+ "tempfile",
+ "toml",
+ "ureq",
+ "url",
+]
+
+[[package]]
+name = "buildpack-heroku-jvm-function-invoker"
+version = "0.0.0"
+dependencies = [
+ "indoc",
+ "libcnb",
+ "libherokubuildpack",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "buildpack-heroku-maven"
+version = "0.0.0"
+dependencies = [
+ "buildpacks-jvm-shared",
+ "indoc",
+ "java-properties",
+ "libcnb",
+ "libcnb-test",
+ "libherokubuildpack",
+ "regex",
+ "serde",
+ "shell-words",
+ "tempfile",
+ "ureq",
+]
+
+[[package]]
+name = "buildpacks-jvm-shared"
+version = "0.0.0"
+dependencies = [
+ "indoc",
+ "libherokubuildpack",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,24 +596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heroku-openjdk"
-version = "0.0.0"
-dependencies = [
- "fs_extra",
- "indoc",
- "java-properties",
- "libcnb",
- "libcnb-test",
- "libherokubuildpack",
- "serde",
- "sha2",
- "tempfile",
- "toml",
- "ureq",
- "url",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,19 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jvm-function-invoker-buildpack"
-version = "0.0.0"
-dependencies = [
- "indoc",
- "libcnb",
- "libherokubuildpack",
- "serde",
- "tempfile",
- "thiserror",
- "toml",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,22 +888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "maven"
-version = "0.0.0"
-dependencies = [
- "indoc",
- "java-properties",
- "libcnb",
- "libcnb-test",
- "libherokubuildpack",
- "regex",
- "serde",
- "shell-words",
- "tempfile",
- "ureq",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,7 @@ dependencies = [
  "libcnb-test",
  "libherokubuildpack",
  "serde",
- "sha2",
  "tempfile",
- "toml",
  "ureq",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ libcnb = "0.11"
 libcnb-test = "0.11"
 libherokubuildpack = "0.11"
 toml = "0.7"
-buildpacks-jvm-shared = { version = "0.0.0", path = "buildpacks-jvm-shared" }
+buildpacks-jvm-shared = { path = "buildpacks-jvm-shared" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
 members = [
+    "buildpacks-jvm-shared",
     "buildpacks/jvm",
-    "buildpacks/maven",
     "buildpacks/jvm-function-invoker",
+    "buildpacks/maven",
 ]
 
 [workspace.package]
@@ -16,3 +17,4 @@ libcnb = "0.11"
 libcnb-test = "0.11"
 libherokubuildpack = "0.11"
 toml = "0.7"
+buildpacks-jvm-shared = { version = "0.0.0", path = "buildpacks-jvm-shared" }

--- a/buildpacks-jvm-shared/Cargo.toml
+++ b/buildpacks-jvm-shared/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "buildpacks-jvm-shared"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+indoc = "2.0.1"
+libherokubuildpack.workspace = true

--- a/buildpacks-jvm-shared/src/lib.rs
+++ b/buildpacks-jvm-shared/src/lib.rs
@@ -1,3 +1,11 @@
+// Enable rustc and Clippy lints that are disabled by default.
+// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
+#![warn(unused_crate_dependencies)]
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+// This lint is too noisy and enforces a style that reduces readability in many cases.
+#![allow(clippy::module_name_repetitions)]
+
 use indoc::formatdoc;
 use libherokubuildpack::log::log_error;
 use std::fmt::Debug;

--- a/buildpacks-jvm-shared/src/lib.rs
+++ b/buildpacks-jvm-shared/src/lib.rs
@@ -1,0 +1,21 @@
+use indoc::formatdoc;
+use libherokubuildpack::log::log_error;
+use std::fmt::Debug;
+
+pub fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
+    header: H,
+    message: M,
+    error: E,
+) {
+    log_error(
+        header,
+        formatdoc! {"
+            {message}
+
+            Please try again. If this error persists, please contact us:
+            https://help.heroku.com/
+
+            Details: {error:?}
+        ", message = message.as_ref(), error = error },
+    );
+}

--- a/buildpacks/jvm-function-invoker/Cargo.toml
+++ b/buildpacks/jvm-function-invoker/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jvm-function-invoker-buildpack"
+name = "buildpack-heroku-jvm-function-invoker"
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "heroku-openjdk"
+name = "buildpack-heroku-jvm"
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+buildpacks-jvm-shared.workspace = true
 fs_extra = "1"
 indoc = "2"
 java-properties = "1"

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -13,9 +13,7 @@ java-properties = "1"
 libcnb.workspace = true
 libherokubuildpack.workspace = true
 serde = { version = "1", features = ["derive"] }
-sha2 = "0.10"
 tempfile = "3"
-toml.workspace = true
 ureq = "2"
 url = "2"
 

--- a/buildpacks/jvm/src/errors.rs
+++ b/buildpacks/jvm/src/errors.rs
@@ -1,10 +1,10 @@
 use crate::{
     NormalizeVersionStringError, OpenJdkBuildpackError, ReadVersionStringError, ValidateSha256Error,
 };
+use buildpacks_jvm_shared::log_please_try_again_error;
 use indoc::formatdoc;
 use libherokubuildpack::download::DownloadError;
 use libherokubuildpack::log::log_error;
-use std::fmt::Debug;
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
@@ -140,22 +140,4 @@ pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
             error,
         ),
     }
-}
-
-fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
-    header: H,
-    message: M,
-    error: E,
-) {
-    log_error(
-        header,
-        formatdoc! {"
-            {message}
-
-            Please try again. If this error persists, please contact us:
-            https://help.heroku.com/
-
-            Details: {error:?}
-        ", message = message.as_ref(), error = error },
-    );
 }

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -1,4 +1,6 @@
 // Enable rustc and Clippy lints that are disabled by default.
+// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
+#![warn(unused_crate_dependencies)]
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.
@@ -27,8 +29,12 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
 use libcnb::Buildpack;
 use libcnb::{buildpack_main, Platform};
+#[cfg(test)]
+use libcnb_test as _;
 use libherokubuildpack::download::DownloadError;
 use serde::{Deserialize, Serialize};
+// Work around unused_crate_dependencies. url is used in heroku_database_env_var_rewrite.
+use url as _;
 
 pub(crate) struct OpenJdkBuildpack;
 

--- a/buildpacks/maven/Cargo.toml
+++ b/buildpacks/maven/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "maven"
+name = "buildpack-heroku-maven"
 version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+buildpacks-jvm-shared.workspace = true
 indoc = "2"
 java-properties = "1"
 libcnb.workspace = true

--- a/buildpacks/maven/src/errors.rs
+++ b/buildpacks/maven/src/errors.rs
@@ -1,7 +1,7 @@
 use crate::{MavenBuildpackError, SettingsError, SystemPropertiesError};
+use buildpacks_jvm_shared::log_please_try_again_error;
 use indoc::formatdoc;
 use libherokubuildpack::log::log_error;
-use std::fmt::Debug;
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
@@ -139,22 +139,4 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
             ", error = error },
         ),
     }
-}
-
-fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
-    header: H,
-    message: M,
-    error: E,
-) {
-    log_error(
-        header,
-        formatdoc! {"
-            {message}
-
-            Please try again. If this error persists, please contact us:
-            https://help.heroku.com/
-
-            Details: {error:?}
-        ", message = message.as_ref(), error = error },
-    );
 }

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -1,4 +1,6 @@
 // Enable rustc and Clippy lints that are disabled by default.
+// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
+#![warn(unused_crate_dependencies)]
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.
@@ -19,6 +21,8 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
 use libcnb::layer_env::Scope;
 use libcnb::{buildpack_main, Buildpack, Env, Error, Platform};
+#[cfg(test)]
+use libcnb_test as _;
 use libherokubuildpack::download::DownloadError;
 use libherokubuildpack::log::{log_header, log_info};
 use serde::{Deserialize, Serialize};
@@ -28,6 +32,8 @@ use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
+#[cfg(test)]
+use ureq as _;
 
 mod errors;
 mod framework;


### PR DESCRIPTION
- Introduce a shared crate for common code between JVM buildpacks
- Moves duplicated `log_please_try_again_error` function to shared crate
- Rename crates to use a consistent naming scheme (this has no effect to the users as they only use the buildpack IDs which don't change)

Ref: GUS-W-13035981