### PR TITLE
Update to libcnb `0.12.0` and buildpack API `0.9`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,9 +786,9 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libcnb"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4fd7573558173267930e31446da65a0275770bde88847cad4b4cf9a6ff8375"
+checksum = "027cd4a736600564c4e7aebf124eabb9d7dc622bcfeefb414cc7c4c7d7ac6595"
 dependencies = [
  "libcnb-data",
  "libcnb-proc-macros",
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-data"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0112478d479c8900929894426818bea8e769ce923536a58baac719d3ca4dcb"
+checksum = "6e8840246c7aced3307fa193edc5d26482f92f992986a33860b6b3b523a67975"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacd18d358a1078cf48f518ef8398c504f8d4fc691ba2e8773bafa1a71d66b59"
+checksum = "27205236a28660f7395598a3f65afb9315de8ce3054c39375b0be673fa6288e7"
 dependencies = [
  "cargo_metadata",
  "libcnb-data",
@@ -824,21 +824,21 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5930cea22615255081c0c44b902e6e8b37a824ebe1374a7c7d52724d5b7d6e4e"
+checksum = "c9e31cc93a20d00f1d54ecb55dcff681669871e6d8a8b63ac0320e77fca1987c"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.12",
 ]
 
 [[package]]
 name = "libcnb-test"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86e8c1847c8ba3c37e30841ee241887203110f4373731e7967706ab77c42b7d"
+checksum = "ff3f26e5f4ad90ea4036618dcba858c567f8c46a281daa72856eab3be0972885"
 dependencies = [
  "bollard",
  "cargo_metadata",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878674906e0140191f89047ef1e8c142cb31becce91b4e64b1b6419fe03da7c1"
+checksum = "4ee2764ebf688454c4fcbcd7c52ff277b5cb2e196c502ff4ce92de563cb10ea2"
 dependencies = [
  "crossbeam-utils",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 publish = false
 
 [workspace.dependencies]
-libcnb = "0.11"
-libcnb-test = "0.11"
-libherokubuildpack = "0.11"
+libcnb = "0.12"
+libcnb-test = "0.12"
+libherokubuildpack = "0.12"
 toml = "0.7"
 buildpacks-jvm-shared = { path = "buildpacks-jvm-shared" }

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
+* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
+
 ## [0.6.7] 2023/01/19
 * Update `sf-fx-runtime-java` from `1.1.2` to `1.1.3`.
 

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/jvm-function-invoker"

--- a/buildpacks/jvm-function-invoker/src/main.rs
+++ b/buildpacks/jvm-function-invoker/src/main.rs
@@ -87,7 +87,7 @@ impl Buildpack for JvmFunctionInvokerBuildpack {
                     .process(
                         ProcessBuilder::new(
                             process_type!("web"),
-                            layers::opt::JVM_RUNTIME_SCRIPT_NAME,
+                            ["bash", layers::opt::JVM_RUNTIME_SCRIPT_NAME],
                         )
                         .default(true)
                         .build(),

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
+* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
+
 ## [1.0.9] 2023/04/24
 
 * Default version for **OpenJDK 8** is now `1.8.0_372`. ([#459](https://github.com/heroku/buildpacks-jvm/pull/459))

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/jvm"

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -4,6 +4,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
+* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
+
 ## [1.0.3] 2022/09/28
 
 * Upgrade `libcnb` and `libherokubuildpack` to `0.11.0`. ([#371](https://github.com/heroku/buildpacks-jvm/pull/371))

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/maven"

--- a/buildpacks/maven/src/framework.rs
+++ b/buildpacks/maven/src/framework.rs
@@ -65,24 +65,30 @@ pub(crate) fn default_app_process<P: AsRef<Path>>(
         (Some(Framework::SpringBoot), Some(main_jar_file_path)) => Some(
             ProcessBuilder::new(
                 process_type!("web"),
-                format!(
-                    "java -Dserver.port=$PORT $JAVA_OPTS -jar {}",
-                    main_jar_file_path.to_string_lossy()
-                ),
+                [
+                    "bash",
+                    "-c",
+                    &format!(
+                        "java -Dserver.port=$PORT $JAVA_OPTS -jar {}",
+                        main_jar_file_path.to_string_lossy()
+                    ),
+                ],
             )
-            .direct(false)
             .default(true)
             .build(),
         ),
         (Some(Framework::WildflySwarm), Some(main_jar_file_path)) => Some(
             ProcessBuilder::new(
                 process_type!("web"),
-                format!(
-                    "java -Dswarm.http.port=$PORT $JAVA_OPTS -jar {}",
-                    main_jar_file_path.to_string_lossy()
-                ),
+                [
+                    "bash",
+                    "-c",
+                    &format!(
+                        "java -Dswarm.http.port=$PORT $JAVA_OPTS -jar {}",
+                        main_jar_file_path.to_string_lossy()
+                    ),
+                ],
             )
-            .direct(false)
             .default(true)
             .build(),
         ),

--- a/buildpacks/sbt/buildpack.toml
+++ b/buildpacks/sbt/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/sbt"

--- a/buildpacks/sbt/src/errors.rs
+++ b/buildpacks/sbt/src/errors.rs
@@ -1,7 +1,6 @@
 use indoc::formatdoc;
 use libcnb::Error;
 use libherokubuildpack::log::log_error;
-use std::ffi::OsString;
 use std::fmt::Debug;
 use std::process::ExitStatus;
 
@@ -27,7 +26,6 @@ pub(crate) enum ScalaBuildpackError {
     CouldNotParseBooleanFromEnvironment(String, std::str::ParseBoolError),
     CouldNotParseListConfigurationFromProperty(String, shell_words::ParseError),
     CouldNotParseListConfigurationFromEnvironment(String, shell_words::ParseError),
-    CouldNotConvertEnvironmentValueIntoString(String, OsString),
     CouldNotReadSbtOptsFile(std::io::Error),
     CouldNotParseListConfigurationFromSbtOptsFile(shell_words::ParseError),
     MissingStageTask,
@@ -129,16 +127,6 @@ pub(crate) fn log_user_errors(error: ScalaBuildpackError) {
 
                 Details: {error}
             " }
-        ),
-
-        ScalaBuildpackError::CouldNotConvertEnvironmentValueIntoString(variable_name, value) => log_error(
-            format!("Invalid {variable_name} environment variable"),
-            formatdoc! {"
-                Could not convert the value of the environment variable {variable_name} into a string. Please
-                check that the value of {variable_name} only contains Unicode characters and try again.
-
-                Value: {value}
-            ", value = value.to_string_lossy() }
         ),
 
         ScalaBuildpackError::CouldNotParseListConfigurationFromSbtOptsFile(error) => log_error(


### PR DESCRIPTION
## Changelog

(applies to all released buildpacks)

* Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))