### PR TITLE
Suppress batch mode warning for sbt `1.x`

### DIFF
--- a/buildpacks/sbt/assets/heroku_buildpack_plugin_sbt_v1.scala
+++ b/buildpacks/sbt/assets/heroku_buildpack_plugin_sbt_v1.scala
@@ -1,10 +1,26 @@
 import sbt._
-import Keys._
+import sbt.Keys._
 
 object HerokuBuildpackPlugin extends AutoPlugin {
+  override def trigger = allRequirements
+
   override lazy val projectSettings = Seq(
     Compile / doc / sources := List(),
     packageDoc / publishArtifact := false,
     packageSrc / publishArtifact := false
+  )
+
+  override lazy val globalSettings = Seq(
+    // sbt will output the following when run in batch mode:
+    // > Executing in batch mode. For better performance use sbt's shell
+    //
+    // This might be confusing to users of the buildpack and is not an actionable warning for them. This key disables
+    // that warning globally.
+    //
+    // See: https://www.scala-sbt.org/1.x/docs/Running.html#Batch+mode
+    //
+    // KeyRanks.Invisible is required to disable warnings by sbt's internal linter for unused keys which yields a
+    // false-positive in the case here.
+    suppressSbtShellNotification.withRank(KeyRanks.Invisible) := true,
   )
 }

--- a/buildpacks/sbt/tests/integration_tests.rs
+++ b/buildpacks/sbt/tests/integration_tests.rs
@@ -1,4 +1,6 @@
-use libcnb_test::{BuildConfig, BuildpackReference, ContainerConfig, TestContext, TestRunner};
+use libcnb_test::{
+    assert_not_contains, BuildConfig, BuildpackReference, ContainerConfig, TestContext, TestRunner,
+};
 use std::path::Path;
 use std::thread;
 use std::time::Duration;
@@ -56,6 +58,17 @@ fn test_play_support_for_v2_7() {
     test_scala_application("scala-play-app-2.7", |ctx| {
         assert_health_check_responds(&ctx);
     })
+}
+
+#[test]
+#[ignore = "integration test"]
+fn test_batch_mode_warning_suppression() {
+    test_scala_application("scala-app-using-coursier", |ctx| {
+        assert_not_contains!(
+            ctx.pack_stdout,
+            "Executing in batch mode. For better performance use sbt's shell"
+        );
+    });
 }
 
 fn test_scala_application(fixture_name: &str, test_body: fn(TestContext)) {


### PR DESCRIPTION
sbt will output the following when run in batch mode:

> Executing in batch mode. For better performance use sbt's shell

This might be confusing to users of the buildpack and is not an actionable warning for them. This PR disables that warning for sbt 1.x projects.
  
https://www.scala-sbt.org/1.x/docs/Running.html#Batch+mode