### PR TITLE
Split `buildpacks-jvm-shared` into modules

### DIFF
--- a/buildpacks/jvm/src/errors.rs
+++ b/buildpacks/jvm/src/errors.rs
@@ -1,5 +1,5 @@
 use crate::{NormalizeVersionStringError, OpenJdkBuildpackError, ValidateSha256Error};
-use buildpacks_jvm_shared::log_please_try_again_error;
+use buildpacks_jvm_shared::log::log_please_try_again_error;
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
 use libherokubuildpack::download::DownloadError;

--- a/buildpacks/maven/src/errors.rs
+++ b/buildpacks/maven/src/errors.rs
@@ -1,5 +1,5 @@
 use crate::{MavenBuildpackError, SettingsError};
-use buildpacks_jvm_shared::log_please_try_again_error;
+use buildpacks_jvm_shared::log::log_please_try_again_error;
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
 use libherokubuildpack::log::log_error;

--- a/buildpacks/sbt/src/cleanup.rs
+++ b/buildpacks/sbt/src/cleanup.rs
@@ -1,4 +1,5 @@
-use buildpacks_jvm_shared::{default_on_not_found, list_directory_contents};
+use buildpacks_jvm_shared::fs::list_directory_contents;
+use buildpacks_jvm_shared::result::default_on_not_found;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;

--- a/buildpacks/sbt/src/detect.rs
+++ b/buildpacks/sbt/src/detect.rs
@@ -1,4 +1,5 @@
-use buildpacks_jvm_shared::{default_on_not_found, list_directory_contents};
+use buildpacks_jvm_shared::fs::list_directory_contents;
+use buildpacks_jvm_shared::result::default_on_not_found;
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};

--- a/buildpacks/sbt/src/errors.rs
+++ b/buildpacks/sbt/src/errors.rs
@@ -2,7 +2,7 @@ use crate::configuration::ReadSbtBuildpackConfigurationError;
 use crate::layers::sbt_extras::SbtExtrasLayerError;
 use crate::layers::sbt_global::SbtGlobalLayerError;
 use crate::sbt_version::ReadSbtVersionError;
-use buildpacks_jvm_shared::log_please_try_again_error;
+use buildpacks_jvm_shared::log::log_please_try_again_error;
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
 use libherokubuildpack::log::log_error;

--- a/buildpacks/sbt/src/main.rs
+++ b/buildpacks/sbt/src/main.rs
@@ -20,7 +20,7 @@ use crate::layers::sbt_boot::SbtBootLayer;
 use crate::layers::sbt_extras::SbtExtrasLayer;
 use crate::layers::sbt_global::SbtGlobalLayer;
 use crate::sbt_version::{is_supported_sbt_version, read_sbt_version};
-use buildpacks_jvm_shared::extend_build_env;
+use buildpacks_jvm_shared::env::extend_build_env;
 use buildpacks_jvm_shared::system_properties::read_system_properties;
 use indoc::formatdoc;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};

--- a/buildpacks/sbt/src/sbt_version.rs
+++ b/buildpacks/sbt/src/sbt_version.rs
@@ -1,4 +1,4 @@
-use buildpacks_jvm_shared::none_on_not_found;
+use buildpacks_jvm_shared::result::none_on_not_found;
 use std::fs;
 use std::path::Path;
 

--- a/shared/src/env.rs
+++ b/shared/src/env.rs
@@ -1,0 +1,8 @@
+use libcnb::layer::LayerData;
+use libcnb::layer_env::Scope;
+use libcnb::Env;
+
+pub fn extend_build_env<T>(value: LayerData<T>, env: &mut Env) -> LayerData<T> {
+    *env = value.env.apply(Scope::Build, env);
+    value
+}

--- a/shared/src/fs.rs
+++ b/shared/src/fs.rs
@@ -1,0 +1,20 @@
+use std::path::{Path, PathBuf};
+
+/// Returns an iterator over the contents of the given directory.
+///
+/// This function is similar to [`std::fs::read_dir`], but collects the errors for the directory
+/// entries before returning an iterator to simplify usage.
+///
+/// # Errors
+/// - The provided path doesn't exist.
+/// - The process lacks permissions to view the contents.
+/// - The path points at a non-directory file.
+/// - An error occurred while reading an entry of the given directory.
+pub fn list_directory_contents<P>(path: P) -> std::io::Result<impl Iterator<Item = PathBuf>>
+where
+    P: AsRef<Path>,
+{
+    std::fs::read_dir(path.as_ref())
+        .and_then(Iterator::collect::<std::io::Result<Vec<_>>>)
+        .map(|dir_entries| dir_entries.into_iter().map(|dir_entry| dir_entry.path()))
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -6,75 +6,8 @@
 // This lint is too noisy and enforces a style that reduces readability in many cases.
 #![allow(clippy::module_name_repetitions)]
 
-use indoc::formatdoc;
-use libcnb::layer::LayerData;
-use libcnb::layer_env::Scope;
-use libcnb::Env;
-use libherokubuildpack::log::log_error;
-use std::fmt::Debug;
-use std::path::{Path, PathBuf};
-
+pub mod env;
+pub mod fs;
+pub mod log;
+pub mod result;
 pub mod system_properties;
-
-pub fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
-    header: H,
-    message: M,
-    error: E,
-) {
-    log_error(
-        header,
-        formatdoc! {"
-            {message}
-
-            Please try again. If this error persists, please contact us:
-            https://help.heroku.com/
-
-            Details: {error:?}
-        ", message = message.as_ref(), error = error },
-    );
-}
-
-/// Returns an iterator over the contents of the given directory.
-///
-/// This function is similar to [`std::fs::read_dir`], but collects the errors for the directory
-/// entries before returning an iterator to simplify usage.
-///
-/// # Errors
-/// - The provided path doesn't exist.
-/// - The process lacks permissions to view the contents.
-/// - The path points at a non-directory file.
-/// - An error occurred while reading an entry of the given directory.
-pub fn list_directory_contents<P>(path: P) -> std::io::Result<impl Iterator<Item = PathBuf>>
-where
-    P: AsRef<Path>,
-{
-    std::fs::read_dir(path.as_ref())
-        .and_then(Iterator::collect::<std::io::Result<Vec<_>>>)
-        .map(|dir_entries| dir_entries.into_iter().map(|dir_entry| dir_entry.path()))
-}
-
-/// Removes [`std::io::Error`] values from a [`Result`] that have the
-/// [`std::io::ErrorKind::NotFound`] error kind by replacing them with the default value for `T`.
-#[allow(clippy::missing_errors_doc)]
-pub fn default_on_not_found<T: Default>(
-    result: Result<T, std::io::Error>,
-) -> Result<T, std::io::Error> {
-    none_on_not_found(result).map(Option::unwrap_or_default)
-}
-
-/// Removes [`std::io::Error`] values from a [`Result`] that have the
-/// [`std::io::ErrorKind::NotFound`] error kind by replacing the `Err(std::io::Error)` with Ok(None).
-#[allow(clippy::missing_errors_doc)]
-pub fn none_on_not_found<T>(
-    result: Result<T, std::io::Error>,
-) -> Result<Option<T>, std::io::Error> {
-    match result {
-        Err(io_error) if io_error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        other => other.map(Some),
-    }
-}
-
-pub fn extend_build_env<T>(value: LayerData<T>, env: &mut Env) -> LayerData<T> {
-    *env = value.env.apply(Scope::Build, env);
-    value
-}

--- a/shared/src/log.rs
+++ b/shared/src/log.rs
@@ -1,0 +1,21 @@
+use indoc::formatdoc;
+use libherokubuildpack::log::log_error;
+use std::fmt::Debug;
+
+pub fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
+    header: H,
+    message: M,
+    error: E,
+) {
+    log_error(
+        header,
+        formatdoc! {"
+            {message}
+
+            Please try again. If this error persists, please contact us:
+            https://help.heroku.com/
+
+            Details: {error:?}
+        ", message = message.as_ref(), error = error },
+    );
+}

--- a/shared/src/result.rs
+++ b/shared/src/result.rs
@@ -1,0 +1,20 @@
+/// Removes [`std::io::Error`] values from a [`Result`] that have the
+/// [`std::io::ErrorKind::NotFound`] error kind by replacing them with the default value for `T`.
+#[allow(clippy::missing_errors_doc)]
+pub fn default_on_not_found<T: Default>(
+    result: Result<T, std::io::Error>,
+) -> Result<T, std::io::Error> {
+    none_on_not_found(result).map(Option::unwrap_or_default)
+}
+
+/// Removes [`std::io::Error`] values from a [`Result`] that have the
+/// [`std::io::ErrorKind::NotFound`] error kind by replacing the `Err(std::io::Error)` with Ok(None).
+#[allow(clippy::missing_errors_doc)]
+pub fn none_on_not_found<T>(
+    result: Result<T, std::io::Error>,
+) -> Result<Option<T>, std::io::Error> {
+    match result {
+        Err(io_error) if io_error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        other => other.map(Some),
+    }
+}

--- a/shared/src/system_properties.rs
+++ b/shared/src/system_properties.rs
@@ -1,4 +1,4 @@
-use crate::none_on_not_found;
+use crate::result::none_on_not_found;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
Most of the functionality was just dumped into `lib.rs`. With the addition of `system_properties.rs` the structure became inconsistent. This PR splits up the functions into separate modules.