### PR TITLE
Migrate to DockerHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Install yj
         uses: buildpacks/github-actions/setup-tools@v5.1.0
       - id: login
-        name: "Login to public ECR"
+        name: "Login to Docker Hub"
         uses: docker/login-action@v2
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: docker.io
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
         env:
           AWS_REGION: us-east-1
       - id: install-musl-tools

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -29,4 +29,4 @@ url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-jav
 sha256 = "b8e17b6ee9889304cbd07958f86ac067cb58c7f6bdd324a87133d377f670adb5"
 [metadata.release]
 [metadata.release.docker]
-repository = "public.ecr.aws/heroku-buildpacks/heroku-jvm-function-invoker-buildpack"
+repository = "docker.io/heroku/buildpack-jvm-function-invoker"

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -29,4 +29,4 @@ url = "https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent
 sha256 = "9a718680e4a93f93a8755b20fb21cc541e5c2692acc9da27c667530f48a716db"
 [metadata.release]
 [metadata.release.docker]
-repository = "public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack"
+repository = "docker.io/heroku/buildpack-jvm"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -41,4 +41,4 @@ url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.3.9.tar.gz"
 sha256 = "72e5a073cd1acb8925a55366a37268d28a5bdde76d4cda4888364068472aa46e"
 [metadata.release]
 [metadata.release.docker]
-repository = "public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack"
+repository = "docker.io/heroku/buildpack-maven"

--- a/buildpacks/sbt/buildpack.toml
+++ b/buildpacks/sbt/buildpack.toml
@@ -23,3 +23,6 @@ id = "heroku-22"
 
 [[stacks]]
 id = "*"
+
+[metadata.release.docker]
+repository = "docker.io/heroku/buildpack-sbt"

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -27,4 +27,4 @@ version = "0.6.7"
 [metadata]
 [metadata.release]
 [metadata.release.docker]
-repository = "public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack"
+repository = "docker.io/heroku/buildpack-java-function"

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -29,4 +29,4 @@ optional = true
 [metadata]
 [metadata.release]
 [metadata.release.docker]
-repository = "public.ecr.aws/heroku-buildpacks/heroku-java-buildpack"
+repository = "docker.io/heroku/buildpack-java"

--- a/meta-buildpacks/scala/buildpack.toml
+++ b/meta-buildpacks/scala/buildpack.toml
@@ -29,4 +29,4 @@ optional = true
 [metadata]
 [metadata.release]
 [metadata.release.docker]
-repository = "public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack"
+repository = "docker.io/heroku/buildpack-scala"


### PR DESCRIPTION
Changes GHA release scripts to login to DockerHub and point buildpack metadata to DockerHub repositories instead of AWS ECR ones. The meta-buildpack dependencies remain unchanged for now - after releasing the non-meta buildpacks to DockerHub, the meta-buildpacks will be changed to point at these.

Repository secrets are already added, ECR credentials will be removed once this PR has been merged and has been confirmed to be working.

Ref: GUS-W-13183203
