### PR TITLE
Post-release updates: heroku/jvm 1.0.10

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.10] 2023/05/10
+
 * Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
 * The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
 

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Upgraded `heroku/jvm` to `1.0.10`
+
 ## [0.3.43] 2023/04/24
 * Upgraded `heroku/jvm` to `1.0.9`
 

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -14,7 +14,7 @@ type = "BSD-3-Clause"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.9"
+version = "1.0.10"
 
 [[order.group]]
 id = "heroku/maven"

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Upgraded `heroku/jvm` to `1.0.10`
 
 ## [0.6.9] 2023/04/24
 * Upgraded `heroku/jvm` to `1.0.9`

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -15,7 +15,7 @@ type = "BSD-3-Clause"
 
 [[order.group]]
 id = "heroku/jvm"
-version = "1.0.9"
+version = "1.0.10"
 
 [[order.group]]
 id = "heroku/maven"

--- a/meta-buildpacks/scala/CHANGELOG.md
+++ b/meta-buildpacks/scala/CHANGELOG.md
@@ -3,5 +3,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Upgraded `heroku/jvm` to `1.0.10`
 * Initial release


### PR DESCRIPTION
Release automation failed with GitHub's incident yesterday. This manual PR carries out the missing updates. Buildpack registry entry is still not added, I'll engage with upstream to get that sorted. https://github.com/buildpacks/registry-index/issues/5408

Ref:  GUS-W-13183203