### PR TITLE
Update meta-buildpacks for DockerHub migration

### DIFF
--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -3,10 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Upgraded `heroku/jvm-function-invoker` to `0.6.9`
-* Upgraded `heroku/maven` to `1.0.5`
-
 * Upgraded `heroku/jvm` to `1.0.10`
+* Upgraded `heroku/maven` to `1.0.4`
+* Upgraded `heroku/jvm-function-invoker` to `0.6.8`
+* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#491](https://github.com/heroku/buildpacks-jvm/pull/491))
 
 ## [0.3.43] 2023/04/24
 * Upgraded `heroku/jvm` to `1.0.9`

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/java-function"
@@ -18,11 +18,11 @@ version = "1.0.10"
 
 [[order.group]]
 id = "heroku/maven"
-version = "1.0.5"
+version = "1.0.4"
 
 [[order.group]]
 id = "heroku/jvm-function-invoker"
-version = "0.6.9"
+version = "0.6.8"
 
 [metadata]
 [metadata.release]

--- a/meta-buildpacks/java-function/package.toml
+++ b/meta-buildpacks/java-function/package.toml
@@ -2,10 +2,10 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:72c75a86bd47264aec475f302e881448c818a980dec2a2ec01c5d70e19983cd5"
+uri = "docker://docker.io/heroku/buildpack-jvm@sha256:de28bad8801d2a55517184a17600a9bdd44c92755664944cf6cb9aa1cca36fc5"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:450ccbb49d5e81bda57ab32637cf9ba53fcd47a1b0af979ea8d090ed122f1cb1"
+uri = "docker://docker.io/heroku/buildpack-maven@sha256:a4d8e60cf3047c04412081619a7c1c8146fa252115c93029a7ae34d699126fe7"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-function-invoker-buildpack@sha256:ed41c88bff972cdd3a58e0035c0c444a5aaaac4898a89287ca9f1ed6a2fa6635"
+uri = "docker://docker.io/heroku/buildpack-jvm-function-invoker@sha256:93320793ed269c88e97c4f3cb8fb94479df7b6d5585d273be933c80b9936a16b"

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -3,8 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Upgraded `heroku/maven` to `1.0.5`
+* Upgraded `heroku/maven` to `1.0.4`
 * Upgraded `heroku/jvm` to `1.0.10`
+* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#491](https://github.com/heroku/buildpacks-jvm/pull/491))
 
 ## [0.6.9] 2023/04/24
 * Upgraded `heroku/jvm` to `1.0.9`

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/java"
@@ -19,7 +19,7 @@ version = "1.0.10"
 
 [[order.group]]
 id = "heroku/maven"
-version = "1.0.5"
+version = "1.0.4"
 
 [[order.group]]
 id = "heroku/procfile"

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -2,10 +2,10 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:72c75a86bd47264aec475f302e881448c818a980dec2a2ec01c5d70e19983cd5"
+uri = "docker://docker.io/heroku/buildpack-jvm@sha256:de28bad8801d2a55517184a17600a9bdd44c92755664944cf6cb9aa1cca36fc5"
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-maven-buildpack@sha256:450ccbb49d5e81bda57ab32637cf9ba53fcd47a1b0af979ea8d090ed122f1cb1"
+uri = "docker://docker.io/heroku/buildpack-maven@sha256:a4d8e60cf3047c04412081619a7c1c8146fa252115c93029a7ae34d699126fe7"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"

--- a/meta-buildpacks/scala/CHANGELOG.md
+++ b/meta-buildpacks/scala/CHANGELOG.md
@@ -3,5 +3,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Upgraded `heroku/sbt` to `1.0.1`
 * Initial release

--- a/meta-buildpacks/scala/buildpack.toml
+++ b/meta-buildpacks/scala/buildpack.toml
@@ -1,12 +1,12 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/scala"
-version = "0.0.1"
+version = "1.0.0"
 name = "Scala"
 homepage = "https://github.com/heroku/buildpacks-jvm"
 description = "Official Heroku buildpack for Scala applications."
-keywords = ["scala", "java"]
+keywords = ["scala"]
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -19,7 +19,7 @@ version = "1.0.10"
 
 [[order.group]]
 id = "heroku/sbt"
-version = "1.0.1"
+version = "1.0.0"
 
 [[order.group]]
 id = "heroku/procfile"

--- a/meta-buildpacks/scala/package.toml
+++ b/meta-buildpacks/scala/package.toml
@@ -2,10 +2,10 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-jvm-buildpack@sha256:bc58cd36e77a1b16709218782fd865df63d3f3c2d25785c8e4a36b381c83a435"
+uri = "docker://docker.io/heroku/buildpack-jvm@sha256:de28bad8801d2a55517184a17600a9bdd44c92755664944cf6cb9aa1cca36fc5"
 
 [[dependencies]]
-#uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-sbt-buildpack@sha256:[NEED TO PUBLISH SBT BUILDPACK FIRST]"
+uri = "docker://docker.io/heroku/buildpack-sbt@sha256:8f928df6e3cf2e8f350a494f0bd3bdfb9c8fb139dec082cee1cc96f71c9f9301"
 
 [[dependencies]]
 uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"


### PR DESCRIPTION
Switching to DockerHub from ECR as well as releasing new buildpacks (`heroku/sbt` and `heroku/scala`) made it necessary to change some metadata for our meta-buildpacks. This PR fixes meta-buildpacks with the correct Docker URLs, versions and CHANGELOG entries.

Ref: GUS-W-13183203