### PR TITLE
maven buildpack environment configuration

### DIFF
--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * This buildpack now declares to be compatible with the `*` stack. While the buildpack cannot guarantee it works with any stack conceivable, it should be compatible with some stacks that are not maintained by Heroku. Use of this buildpack on such stacks is unsupported. ([#498](https://github.com/heroku/buildpacks-jvm/pull/498))
+* Allow `JAVA_HOME` to be set by user or operator via `<platform>/env`. ([#508](https://github.com/heroku/buildpacks-jvm/pull/508))
+* `MAVEN_SETTINGS_PATH`, `MAVEN_ESTTINGS_URL`, `MAVEN_CUSTOM_GOALS`, and `MAVEN_CUSTOM_OPTS` can be set by a previous buildpack. ([#508](https://github.com/heroku/buildpacks-jvm/pull/508))
 
 ## [1.0.4] 2023/05/11
 

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -127,7 +127,7 @@ impl Buildpack for MavenBuildpack {
 
         log_header("Installing Maven");
 
-        let (mvn_executable, mvn_env) = match maven_mode {
+        let (mvn_executable, mut mvn_env) = match maven_mode {
             Mode::UseWrapper => {
                 log_info("Maven wrapper detected, skipping installation.");
 
@@ -184,6 +184,9 @@ impl Buildpack for MavenBuildpack {
                 )
             }
         };
+        if let Some(java_home) = current_or_platform_env.get("JAVA_HOME") {
+            mvn_env.insert("JAVA_HOME", java_home);
+        }
 
         let maven_goals = current_or_platform_env
             .get("MAVEN_CUSTOM_GOALS")


### PR DESCRIPTION
## Context

### `JAVA_HOME`
At Salesforce, we're trying to use the `heroku/maven` buildpack outside of the standard heroku builder images. Unfortunately, `which` is not in the base image which causes the `mvn` binary to fail while it's trying to find the java command:

```
[builder] [Executing Maven]                                                                                                                                                                                                                                                       
[builder] $ mvn -DskipTests clean install                                                                                                                                                                                                                                         
[builder] /layers/heroku_maven/maven/bin/mvn: line 93: which: command not found 
```

If `JAVA_HOME` is set, then `mvn` does not execute `which`.

### NEXUS Buildpack Compatibility
Secondly, the buildpack today only reads env var from the `<platform>/env` directory which only captures env vars set by the user or operator. If a prior buildpack sets a build time env var it gets ignored since `lifecycle` will set this in the current environment. This breaks a nexus buildpack that writes out a `settings.xml` with `MAVEN_SETTINGS_PATH` defined.

## Changes
This PR introduces two changes that fix the issues for us.

1. In the maven buildpack when reading env vars from `<platform>/env` also check the current env as a fallback, so user/operator env vars take precedence.
2. Set `JAVA_HOME` in the env when `mvn` is executed, so it honors the env var.

## TODO
Happy to do these items assuming you're ok with these changes:

- [ ] Add tests
- [ ] Add changelog