### PR TITLE
Uses the expanded properties exposed by the detect workflow

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -13,7 +13,7 @@ jobs:
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-detect.yml@main
 
   package:
-    name: ${{ matrix.id }}
+    name: ${{ matrix.buildpack_id }}
     needs: [ detect ]
     strategy:
       fail-fast: false
@@ -21,11 +21,13 @@ jobs:
         include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-package.yml@main
     with:
-      buildpack_id: ${{ matrix.id }}
-      buildpack_path: ${{ matrix.path }}
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_dir: ${{ matrix.buildpack_dir }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
 
   publish-docker:
-    name: ${{ matrix.id }}
+    name: ${{ matrix.buildpack_id }}
     needs: [ detect, package ]
     strategy:
       fail-fast: false
@@ -33,13 +35,16 @@ jobs:
         include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-docker.yml@main
     with:
-      buildpack_id: ${{ matrix.id }}
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
+      docker_repository: ${{ matrix.docker_repository }}
     secrets:
       docker_hub_user: ${{ secrets.DOCKER_HUB_USER }}
       docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
   publish-github:
-    name: ${{ matrix.id }}
+    name: ${{ matrix.buildpack_id }}
     needs: [ detect, package ]
     strategy:
       fail-fast: false
@@ -47,10 +52,11 @@ jobs:
         include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-github.yml@main
     with:
-      buildpack_id: ${{ matrix.id }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
 
   publish-cnb:
-    name: ${{ matrix.id }}
+    name: ${{ matrix.buildpack_id }}
     needs: [ detect, publish-docker ]
     strategy:
       fail-fast: false
@@ -58,20 +64,18 @@ jobs:
         include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-cnb-registry.yml@main
     with:
-      buildpack_id: ${{ matrix.id }}
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      docker_repository: ${{ matrix.docker_repository }}
     secrets:
       cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
 
   update-builder:
-    name: ${{ matrix.id }}
+    name: Update Builder
     needs: [ detect, publish-docker, publish-cnb, publish-github ]
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-update-builder.yml@main
     with:
-      buildpack_id: ${{ matrix.id }}
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+      buildpack_version: ${{ needs.detect.outputs.version }}
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}


### PR DESCRIPTION
Changes to the workflow to use the extra properties exposed during the `detect` workflow.  I.e.;

* `[buildpacks]` 
  * `buildpack_id`
  * `buildpack_version`
  * `buildpack_dir`
  * `buildpack_artifact_prefix`
  * `docker_repository`
* `version`

Depends on https://github.com/heroku/languages-github-actions/pull/32