### PR TITLE
Group libcnb Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      libcnb:
+        patterns:
+          - "libcnb*"
+          - "libherokubuildpack"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This makes use of Dependabot's new `groups` feature to ensure that only a single PR is opened for all libcnb.rs crate updates, given that all libcnb.rs crates should be updated at the same time.

See:
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/ https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

GUS-W-13708140.