### PR TITLE
Use HTTPS instead of SSH for Git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,8 @@
 
 [submodule "buildpacks/sbt/test-apps/heroku-scala-getting-started"]
 	path = buildpacks/sbt/test-apps/heroku-scala-getting-started
-	url = git@github.com:heroku/scala-getting-started.git
+	url = https://github.com/heroku/scala-getting-started.git
+
 [submodule "buildpacks/maven/test-apps/heroku-java-getting-started"]
 	path = buildpacks/maven/test-apps/heroku-java-getting-started
-	url = git@github.com:heroku/java-getting-started.git
+	url = https://github.com/heroku/java-getting-started.git


### PR DESCRIPTION
Some of the Git submodules previously used SSH instead of HTTPS, which:
- Causes errors in environments where SSH auth isn't configured (such as when people prefer to use HTTPS auth for GitHub, but use a different SSH key for other use-cases, and use a wildcard in the SSH config).
- Is unnecessary, given these are public repos so don't need auth to read.
- Was inconsistent, given that some of the Git submodules already used HTTPS.

This fixes the following errors I get locally:

```
$ git submodule update
Cloning into '/Users/emorley/src/buildpacks-jvm/buildpacks/maven/test-apps/heroku-java-getting-started'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

GUS-W-13745392.