### PR TITLE
Remove vulnerable Maven versions, add support for 3.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ version = "0.0.0"
 dependencies = [
  "buildpacks-jvm-shared",
  "buildpacks-jvm-shared-test",
+ "flate2",
  "indoc",
  "java-properties",
  "libcnb",
@@ -197,6 +198,7 @@ dependencies = [
  "regex",
  "serde",
  "shell-words",
+ "tar",
  "tempfile",
 ]
 
@@ -1284,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
 dependencies = [
  "filetime",
  "libc",
@@ -1767,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "0.2.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove support for installing Maven `3.2.5`, `3.3.9`, `3.5.4` and `3.6.2` via `system.properties`. These versions of Maven contain security vulnerabilities and should not be used. Users that cannot upgrade to a secure version of Maven can install the Maven Wrapper for the required Maven version to their application (i.e. `mvn wrapper:wrapper -Dmaven=3.6.2`). ([#556](https://github.com/heroku/buildpacks-jvm/pull/556))
+- Default version for Maven is now `3.9.4`. ([#556](https://github.com/heroku/buildpacks-jvm/pull/556))
+
 ## [2.0.0] - 2023-07-31
 
 - No changes.

--- a/buildpacks/maven/Cargo.toml
+++ b/buildpacks/maven/Cargo.toml
@@ -14,6 +14,8 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 shell-words = "1"
 tempfile = "3"
+flate2 = "1.0.26"
+tar = "0.4.39"
 
 [dev-dependencies]
 libcnb-test.workspace = true

--- a/buildpacks/maven/README.md
+++ b/buildpacks/maven/README.md
@@ -16,8 +16,8 @@ Users can specify the Maven version for their application by adding (or extendin
 [Java properties file](https://en.wikipedia.org/wiki/.properties) called `system.properties` in the root directory of
 the application.
 
-The `maven.version` key determines the Maven version that is installed. Currently, supported versions are `3.2.5`,
-`3.3.9`, `3.5.3`, and `3.6.2`. The default is `3.6.2`.
+The `maven.version` key determines the Maven version that is installed. Currently, the only supported version is 
+`3.9.4`. The default is `3.9.4`.
 
 ### Step 2: Resolve settings.xml
 A Maven `settings.xml` file defines values that configure Maven execution in various ways. Most commonly, it is used to

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -16,20 +16,11 @@ type = "BSD-3-Clause"
 id = "*"
 
 [metadata]
-default-version = "3.6.2"
+default-version = "3.9.4"
 [metadata.tarballs]
-[metadata.tarballs."3.2.5"]
-url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.2.5.tar.gz"
-sha256 = "bd37fad4863cd01524f31ada88ce9f0632040976d64561157cafc98959764341"
-[metadata.tarballs."3.6.2"]
-url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.6.2.tar.gz"
-sha256 = "63fe4e0bf88d5ec732736f4baa2b62172e654130e16c1db02c252c639b9fd3df"
-[metadata.tarballs."3.5.4"]
-url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.5.4.tar.gz"
-sha256 = "2fa7a911bfef93a3bc0699674efd307a53da28f9179a50b10d183080b1f5bbc0"
-[metadata.tarballs."3.3.9"]
-url = "https://lang-jvm.s3.us-east-1.amazonaws.com/maven-3.3.9.tar.gz"
-sha256 = "72e5a073cd1acb8925a55366a37268d28a5bdde76d4cda4888364068472aa46e"
+[metadata.tarballs."3.9.4"]
+url = "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.tar.gz"
+sha256 = "ff66b70c830a38d331d44f6c25a37b582471def9a161c93902bac7bea3098319"
 [metadata.release]
 [metadata.release.image]
 repository = "docker.io/heroku/buildpack-maven"

--- a/buildpacks/maven/src/errors.rs
+++ b/buildpacks/maven/src/errors.rs
@@ -27,11 +27,6 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
             "Failed to set executable bit for Maven wrapper",
             error,
         ),
-        MavenBuildpackError::MavenTarballNormalizationError(error) => log_please_try_again_error(
-            "Maven distribution post-processing error",
-            "Could not post-process the downloaded Maven distribution.",
-            error,
-        ),
         MavenBuildpackError::DefaultAppProcessError(error) => log_please_try_again_error(
             "Could not determine default process",
             "While trying to determine a default process based on the used application framework, an unexpected error occurred.",

--- a/buildpacks/maven/src/layer/maven.rs
+++ b/buildpacks/maven/src/layer/maven.rs
@@ -1,4 +1,4 @@
-use crate::{util, MavenBuildpack, MavenBuildpackError, Tarball};
+use crate::{MavenBuildpack, MavenBuildpackError, Tarball};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
@@ -58,20 +58,6 @@ impl Layer for MavenLayer {
             layer_path,
         )
         .map_err(MavenBuildpackError::MavenTarballDecompressError)?;
-
-        // The actual Maven installation is located in the .maven subdirectory of the tarball. We
-        // need to move its contents to the layer itself before it can be used:
-        util::move_directory_contents(layer_path.join(".maven"), layer_path)
-            .map_err(MavenBuildpackError::MavenTarballNormalizationError)?;
-
-        std::fs::remove_dir_all(layer_path.join(".maven"))
-            .map_err(MavenBuildpackError::MavenTarballNormalizationError)?;
-
-        // Heroku's Maven tarballs historically also contained a .m2 directory with pre-populated
-        // dependencies for faster builds. For all recent Maven versions, this directory is
-        // empty and unused.
-        std::fs::remove_dir_all(layer_path.join(".m2"))
-            .map_err(MavenBuildpackError::MavenTarballNormalizationError)?;
 
         // Even though M2_HOME is no longer supported by Maven versions >= 3.5.0, other tooling such
         // as Maven invoker might still depend on it. References:

--- a/buildpacks/maven/src/layer/maven.rs
+++ b/buildpacks/maven/src/layer/maven.rs
@@ -1,3 +1,4 @@
+use crate::util::extract_tarball;
 use crate::{MavenBuildpack, MavenBuildpackError, Tarball};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
@@ -53,11 +54,8 @@ impl Layer for MavenLayer {
                 }
             })?;
 
-        libherokubuildpack::tar::decompress_tarball(
-            &mut File::open(&temp_file_path).unwrap(),
-            layer_path,
-        )
-        .map_err(MavenBuildpackError::MavenTarballDecompressError)?;
+        extract_tarball(&mut File::open(&temp_file_path).unwrap(), layer_path, 1)
+            .map_err(MavenBuildpackError::MavenTarballDecompressError)?;
 
         // Even though M2_HOME is no longer supported by Maven versions >= 3.5.0, other tooling such
         // as Maven invoker might still depend on it. References:

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -59,7 +59,6 @@ pub(crate) enum MavenBuildpackError {
         actual_sha256: String,
     },
     MavenTarballDecompressError(std::io::Error),
-    MavenTarballNormalizationError(std::io::Error),
     CannotSplitMavenCustomOpts(shell_words::ParseError),
     CannotSplitMavenCustomGoals(shell_words::ParseError),
     DetermineModeError(ReadSystemPropertiesError),

--- a/buildpacks/maven/tests/integration/versions.rs
+++ b/buildpacks/maven/tests/integration/versions.rs
@@ -20,17 +20,17 @@ fn with_wrapper_and_system_properties() {
     TestRunner::default().build(
         default_config().app_dir_preprocessor(|path| {
             remove_maven_wrapper(&path);
-            set_maven_version_app_dir_preprocessor(PREVIOUS_MAVEN_VERSION, &path)
+            set_maven_version_app_dir_preprocessor(DEFAULT_MAVEN_VERSION, &path)
         }),
         |context| {
             assert_contains!(
                 context.pack_stdout,
-                &format!("Selected Maven version: {PREVIOUS_MAVEN_VERSION}")
+                &format!("Selected Maven version: {DEFAULT_MAVEN_VERSION}")
             );
             assert_not_contains!(context.pack_stdout, "$ ./mvnw");
             assert_contains!(
                 context.pack_stdout,
-                &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {PREVIOUS_MAVEN_VERSION}")
+                &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {DEFAULT_MAVEN_VERSION}")
             );
         },
     )
@@ -88,71 +88,17 @@ fn without_wrapper_and_unknown_system_properties() {
 
 #[test]
 #[ignore = "integration test"]
-fn without_wrapper_and_maven_3_6_2_system_properties() {
+fn without_wrapper_and_maven_3_9_4_system_properties() {
     TestRunner::default().build(
         default_config().app_dir_preprocessor(|path| {
             remove_maven_wrapper(&path);
-            set_maven_version_app_dir_preprocessor("3.6.2", &path);
+            set_maven_version_app_dir_preprocessor("3.9.4", &path);
         }),
         |context| {
-            assert_contains!(context.pack_stdout, "Selected Maven version: 3.6.2");
+            assert_contains!(context.pack_stdout, "Selected Maven version: 3.9.4");
             assert_contains!(
                 context.pack_stdout,
-                "[BUILDPACK INTEGRATION TEST - MAVEN VERSION] 3.6.2"
-            );
-        },
-    )
-}
-
-#[test]
-#[ignore = "integration test"]
-fn without_wrapper_and_maven_3_5_4_system_properties() {
-    TestRunner::default().build(
-        default_config().app_dir_preprocessor(|path| {
-            remove_maven_wrapper(&path);
-            set_maven_version_app_dir_preprocessor("3.5.4", &path);
-        }),
-        |context| {
-            assert_contains!(context.pack_stdout, "Selected Maven version: 3.5.4");
-            assert_contains!(
-                context.pack_stdout,
-                "[BUILDPACK INTEGRATION TEST - MAVEN VERSION] 3.5.4"
-            );
-        },
-    )
-}
-
-#[test]
-#[ignore = "integration test"]
-fn without_wrapper_and_maven_3_3_9_system_properties() {
-    TestRunner::default().build(
-        default_config().app_dir_preprocessor(|path| {
-            remove_maven_wrapper(&path);
-            set_maven_version_app_dir_preprocessor("3.3.9", &path);
-        }),
-        |context| {
-            assert_contains!(context.pack_stdout, "Selected Maven version: 3.3.9");
-            assert_contains!(
-                context.pack_stdout,
-                "[BUILDPACK INTEGRATION TEST - MAVEN VERSION] 3.3.9"
-            );
-        },
-    )
-}
-
-#[test]
-#[ignore = "integration test"]
-fn without_wrapper_and_maven_3_2_5_system_properties() {
-    TestRunner::default().build(
-        default_config().app_dir_preprocessor(|path| {
-            remove_maven_wrapper(&path);
-            set_maven_version_app_dir_preprocessor("3.2.5", &path);
-        }),
-        |context| {
-            assert_contains!(context.pack_stdout, "Selected Maven version: 3.2.5");
-            assert_contains!(
-                context.pack_stdout,
-                "[BUILDPACK INTEGRATION TEST - MAVEN VERSION] 3.2.5"
+                "[BUILDPACK INTEGRATION TEST - MAVEN VERSION] 3.9.4"
             );
         },
     )
@@ -177,7 +123,6 @@ fn set_maven_version_app_dir_preprocessor(version: &str, path: &Path) {
     java_properties::write(&mut properties_file, &properties).unwrap();
 }
 
-const DEFAULT_MAVEN_VERSION: &str = "3.6.2";
-const PREVIOUS_MAVEN_VERSION: &str = "3.5.4";
+const DEFAULT_MAVEN_VERSION: &str = "3.9.4";
 const UNKNOWN_MAVEN_VERSION: &str = "1.0.0-unknown-version";
 const SIMPLE_HTTP_SERVICE_MAVEN_WRAPPER_VERSION: &str = "3.6.3";


### PR DESCRIPTION
The list of supported Maven versions that are being installed only contained versions with security issues. Most notably [CVE-2022-29599](https://nvd.nist.gov/vuln/detail/CVE-2022-29599). This PR removes these versions as valid versions and adds the most recent `3.x` version of Maven as the only supported (and therefore default) version.

- Update README with updated info about available Maven versions and the default.
- Remove integration tests for now unsupported versions.
- Use Apache's repository for downloading of the Maven distribution, this makes it easier to add  new supported versions in the future.
  - These tarballs are different from the ones installed previously. We no longer need to normalize the contents, but now need to strip the first component since it contains the version number. 

Closes GUS-W-13904493