### PR TITLE
Add support for overriding Maven download mirror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "shell-words",
  "tar",
  "tempfile",
+ "url",
 ]
 
 [[package]]
@@ -1057,6 +1058,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for overriding the mirror from which Maven is downloaded from. The default continues to be `https://repo.maven.apache.org/maven2/`. Use the `MAVEN_DOWNLOAD_MIRROR` environment variable to configure a different base URL. This setting has no effect when Maven Wrapper is used. ([#559](https://github.com/heroku/buildpacks-jvm/pull/559))
+
 ## [3.0.0] - 2023-08-09
 
 - Remove support for installing Maven `3.2.5`, `3.3.9`, `3.5.4` and `3.6.2` via `system.properties`. These versions of Maven contain security vulnerabilities and should not be used. Users that cannot upgrade to a secure version of Maven can install the Maven Wrapper for the required Maven version to their application (i.e. `mvn wrapper:wrapper -Dmaven=3.6.2`). ([#556](https://github.com/heroku/buildpacks-jvm/pull/556))

--- a/buildpacks/maven/Cargo.toml
+++ b/buildpacks/maven/Cargo.toml
@@ -16,6 +16,7 @@ shell-words = "1"
 tempfile = "3"
 flate2 = "1.0.26"
 tar = "0.4.39"
+url = { version = "2.4.0", features = ["serde"] }
 
 [dev-dependencies]
 libcnb-test.workspace = true

--- a/buildpacks/maven/README.md
+++ b/buildpacks/maven/README.md
@@ -82,6 +82,8 @@ Allows overriding the Maven goals used during the build process. The default goa
 Allows overriding the Java options for the Maven process during build. The default Java options are `-Xmx1024m`.
 #### `HEROKU_BUILDPACK_DEBUG`
 If set, the buildpack will emit debug log messages.
+#### `MAVEN_DOWNLOAD_MIRROR`
+If set, the buildpack will use this value as the root URL for downloading Maven distributions. The default is `https://repo.maven.apache.org/maven2/`. Has no effect when Maven Wrapper is used.
 
 ## License
 See [LICENSE](../../LICENSE) file.

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -16,11 +16,12 @@ type = "BSD-3-Clause"
 id = "*"
 
 [metadata]
-default-version = "3.9.4"
-[metadata.tarballs]
-[metadata.tarballs."3.9.4"]
-url = "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.tar.gz"
+default-maven-version = "3.9.4"
+default-apache-maven-mirror = "https://repo.maven.apache.org/maven2/"
+
+[metadata.maven-versions."3.9.4"]
+path = "org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.tar.gz"
 sha256 = "ff66b70c830a38d331d44f6c25a37b582471def9a161c93902bac7bea3098319"
-[metadata.release]
+
 [metadata.release.image]
 repository = "docker.io/heroku/buildpack-maven"

--- a/buildpacks/maven/src/errors.rs
+++ b/buildpacks/maven/src/errors.rs
@@ -134,5 +134,14 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
                 Details: {error}
             ", error = error },
         ),
+        MavenBuildpackError::InvalidMavenDownloadMirror(error) => log_error(
+            "Invalid Maven Download Mirror",
+            formatdoc! {"
+                Could not parse the value of the MAVEN_DOWNLOAD_MIRROR environment variable as a
+                base URL. Please ensure that the value is a valid URL and and try again.
+
+                Details: {error}
+            ", error = error },
+        ),
     }
 }

--- a/buildpacks/maven/tests/integration/download_mirror.rs
+++ b/buildpacks/maven/tests/integration/download_mirror.rs
@@ -1,0 +1,36 @@
+use crate::{default_config, remove_maven_wrapper};
+use libcnb_test::{assert_contains, PackResult, TestRunner};
+
+#[test]
+#[ignore = "integration test"]
+fn download_mirror() {
+    TestRunner::default().build(
+        default_config()
+            .env("MAVEN_DOWNLOAD_MIRROR", "https://repo1.maven.org/maven2/")
+            .app_dir_preprocessor(|path| {
+                remove_maven_wrapper(&path);
+            }),
+        |_| {
+            // Intentionally empty, we only care that it builds.
+        },
+    )
+}
+
+#[test]
+#[ignore = "integration test"]
+fn invalid_url() {
+    TestRunner::default().build(
+        default_config()
+            .env("MAVEN_DOWNLOAD_MIRROR", "Not a valid base URL")
+            .app_dir_preprocessor(|path| {
+                remove_maven_wrapper(&path);
+            })
+            .expected_pack_result(PackResult::Failure),
+        |context| {
+            assert_contains!(
+                context.pack_stderr,
+                "[Error: Invalid Maven Download Mirror]"
+            );
+        },
+    )
+}

--- a/buildpacks/maven/tests/integration/main.rs
+++ b/buildpacks/maven/tests/integration/main.rs
@@ -7,10 +7,12 @@
 
 use buildpacks_jvm_shared_test::DEFAULT_INTEGRATION_TEST_BUILDER;
 use libcnb_test::{BuildConfig, BuildpackReference};
+use std::path::Path;
 
 mod automatic_process_type;
 mod caching;
 mod customization;
+mod download_mirror;
 mod misc;
 mod polyglot;
 mod settings_xml;
@@ -31,4 +33,8 @@ pub(crate) fn default_buildpacks() -> Vec<BuildpackReference> {
         BuildpackReference::Other(String::from("heroku/jvm")),
         BuildpackReference::Crate,
     ]
+}
+
+pub(crate) fn remove_maven_wrapper(path: &Path) {
+    std::fs::remove_file(path.join("mvnw")).unwrap()
 }

--- a/buildpacks/maven/tests/integration/versions.rs
+++ b/buildpacks/maven/tests/integration/versions.rs
@@ -1,4 +1,4 @@
-use crate::default_config;
+use crate::{default_config, remove_maven_wrapper};
 use libcnb_test::{assert_contains, assert_not_contains, PackResult, TestRunner};
 use std::fs::OpenOptions;
 use std::path::Path;
@@ -102,10 +102,6 @@ fn without_wrapper_and_maven_3_9_4_system_properties() {
             );
         },
     )
-}
-
-fn remove_maven_wrapper(path: &Path) {
-    std::fs::remove_file(path.join("mvnw")).unwrap()
 }
 
 fn set_maven_version_app_dir_preprocessor(version: &str, path: &Path) {


### PR DESCRIPTION
## Changelog: 
- Add support for overriding the mirror from which Maven is downloaded from. The default continues to be `https://repo.maven.apache.org/maven2/`. Use the `MAVEN_DOWNLOAD_MIRROR` environment variable to configure a different base URL. This setting has no effect when Maven Wrapper is used. ([#559](https://github.com/heroku/buildpacks-jvm/pull/559))