### PR TITLE
Set an explicit libcnb dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ edition = "2021"
 publish = false
 
 [workspace.dependencies]
-libcnb = "0.14"
-libcnb-test = "0.14"
-libherokubuildpack = "0.14"
+# libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
+# so it's pinned to an exact version to isolate it from lockfile refreshes.
+libcnb = "=0.14.0"
+libcnb-test = "=0.14.0"
+libherokubuildpack = "=0.14.0"
 toml = "0.7"
 buildpacks-jvm-shared = { path = "shared" }
 buildpacks-jvm-shared-test = { path = "shared-test" }


### PR DESCRIPTION
So that any refreshes to `Cargo.lock` don't cause libcnb to get update to an in-range version (since libcnb is such an integral part of buildpack behaviour).

This is the approach now used by the other CNBs.