### PR TITLE
Add libcnb-cargo's default output directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+packaged/
 **/target/
 .DS_Store


### PR DESCRIPTION
This is the new default `cargo libcnb package` directory as of libcnb-cargo 0.14.0.