### PR TITLE
Update Procfile CNB to v2.0.1

### DIFF
--- a/buildpacks/sbt/tests/integration/main.rs
+++ b/buildpacks/sbt/tests/integration/main.rs
@@ -16,6 +16,8 @@ pub(crate) fn default_buildpacks() -> Vec<BuildpackReference> {
     vec![
         BuildpackReference::Other(String::from("heroku/jvm")),
         BuildpackReference::Crate,
-        BuildpackReference::Other(String::from("heroku/procfile")),
+        // Using an explicit version from Docker Hub to prevent failures when there
+        // are multiple Procfile buildpack versions in the builder image.
+        BuildpackReference::Other(String::from("docker://docker.io/heroku/procfile-cnb:2.0.1")),
     ]
 }

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated `heroku/procfile` to `2.0.1`. ([#568](https://github.com/heroku/buildpacks-jvm/pull/568))
+
 ## [3.0.0] - 2023-08-09
 
 - Updated `heroku/jvm` to `3.0.0`.

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -23,7 +23,7 @@ version = "3.0.0"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "2.0.0"
+version = "2.0.1"
 optional = true
 
 [metadata]

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -8,4 +8,4 @@ uri = "libcnb:heroku/jvm"
 uri = "libcnb:heroku/maven"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"

--- a/meta-buildpacks/scala/CHANGELOG.md
+++ b/meta-buildpacks/scala/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated `heroku/procfile` to `2.0.1`. ([#568](https://github.com/heroku/buildpacks-jvm/pull/568))
+
 ## [3.0.0] - 2023-08-09
 
 - Updated `heroku/jvm` to `3.0.0`.

--- a/meta-buildpacks/scala/buildpack.toml
+++ b/meta-buildpacks/scala/buildpack.toml
@@ -23,7 +23,7 @@ version = "3.0.0"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "2.0.0"
+version = "2.0.1"
 optional = true
 
 [metadata]

--- a/meta-buildpacks/scala/package.toml
+++ b/meta-buildpacks/scala/package.toml
@@ -8,4 +8,4 @@ uri = "libcnb:heroku/jvm"
 uri = "libcnb:heroku/sbt"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"


### PR DESCRIPTION
Since there has been a new Procfile CNB release:
https://github.com/heroku/procfile-cnb/releases/tag/v2.0.1
https://github.com/heroku/procfile-cnb/compare/v2.0.0...v2.0.1

Also:
- Uses an explicit Procfile CNB version in tests, to prevent test failures when the builder image contains multiple versions (which is the cause of the [CI failures](https://github.com/heroku/buildpacks-jvm/actions/runs/5923710055/job/16071591887#step:8:105) currently seen on `main`).
- Switches the buildpack URI to using the image SHA256, for parity with the URI used in `heroku/builder`.

GUS-W-13982665.