### PR TITLE
Switch to `workspace.resolver=2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "1"
+resolver = "2"
 
 members = [
     "buildpacks/jvm",

--- a/buildpacks/sbt/Cargo.toml
+++ b/buildpacks/sbt/Cargo.toml
@@ -13,7 +13,7 @@ java-properties = "2"
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"
 thiserror = "1"
-semver="1"
+semver = { version = "1", features = ["serde"] }
 shell-words = "1"
 buildpacks-jvm-shared.workspace = true
 


### PR DESCRIPTION
Switches to the [newer resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) for the workspace after fixing `sbt`'s dependencies to work with the new resolver.

GUS-W-14109413