### PR TITLE
Switch tests from `heroku/buildpacks:20` to `heroku/builder:20`

### DIFF
--- a/buildpacks/jvm/tests/integration/versions.rs
+++ b/buildpacks/jvm/tests/integration/versions.rs
@@ -4,7 +4,7 @@ use libcnb_test::{assert_contains, BuildConfig, TestRunner};
 #[ignore = "integration test"]
 fn test_openjdk_8_distribution_heroku_20() {
     TestRunner::default().build(
-        BuildConfig::new("heroku/buildpacks:20", "test-apps/java-8-app"),
+        BuildConfig::new("heroku/builder:20", "test-apps/java-8-app"),
         |context| {
             assert_contains!(
                 context.run_shell_command("java -version").stderr,


### PR DESCRIPTION
Since the `heroku/buildpacks:20` image is about to be deprecated, and has been replaced by the newly added `heroku/builder:20` for those that need to use a Heroku-20 based builder.

The build and run images used by `heroku/builder:20` are the same as those used by `heroku/buildpacks:20` - the only differences between the builders are the included buildpacks (which is somewhat irrelevant for these integration tests, since the buildpack under test will be injected instead).

The smoke tests in the `heroku/builder` GitHub repo are still testing against all image variants (until such time as we make the legacy images error with an EOL message), so we still have test coverage against them.

See:
https://github.com/heroku/builder/pull/394
https://salesforce.quip.com/0JtbAYiWZYk6

GUS-W-14186015.