### PR TITLE
Fix lint errors with Rust 1.73

### DIFF
--- a/buildpacks/maven/src/settings.rs
+++ b/buildpacks/maven/src/settings.rs
@@ -45,7 +45,7 @@ fn handle_maven_settings_url_env_var(env: &Env) -> Option<Result<PathBuf, Settin
                     error,
                 )
             })
-            .map(|_| path)
+            .map(|()| path)
     })
 }
 


### PR DESCRIPTION
To unblock #596.

Fixed using `cargo clippy --all-targets --fix`.

`warning: matching over () is more explicit`
https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns

As seen in:
https://github.com/heroku/buildpacks-jvm/actions/runs/6456042926/job/17524720674?pr=596