### PR TITLE
Update buildpack metadata in buildpack.toml

### DIFF
--- a/buildpacks/gradle/CHANGELOG.md
+++ b/buildpacks/gradle/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#603](https://github.com/heroku/buildpacks-jvm/pull/603))
+
 ## [3.2.1] - 2023-10-19
 
 - No changes.

--- a/buildpacks/gradle/buildpack.toml
+++ b/buildpacks/gradle/buildpack.toml
@@ -3,11 +3,11 @@ api = "0.9"
 [buildpack]
 id = "heroku/gradle"
 version = "3.2.1"
-name = "Gradle"
-clear-env = true
+name = "Heroku Gradle"
 homepage = "https://github.com/heroku/buildpacks-jvm"
-description = "Official Heroku buildpack for Gradle applications."
-keywords = ["java", "gradle"]
+description = "Heroku's Gradle buildpack. A component of the 'heroku/java' buildpack."
+keywords = ["gradle", "heroku"]
+clear-env = true
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -15,7 +15,5 @@ type = "BSD-3-Clause"
 [[stacks]]
 id = "*"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-gradle"
+image = { repository = "docker.io/heroku/buildpack-gradle" }

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#603](https://github.com/heroku/buildpacks-jvm/pull/603))
+
 ## [3.2.1] - 2023-10-19
 
 - No changes.

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -3,10 +3,10 @@ api = "0.9"
 [buildpack]
 id = "heroku/jvm-function-invoker"
 version = "3.2.1"
-name = "JVM Function Invoker"
-clear-env = true
+name = "Salesforce JVM Function Invoker"
 homepage = "https://github.com/heroku/buildpacks-jvm"
-keywords = ["java", "function"]
+description = "Salesforce's JVM function invoker buildpack. A component of the 'heroku/java-function' buildpack."
+clear-env = true
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -14,10 +14,9 @@ type = "BSD-3-Clause"
 [[stacks]]
 id = "*"
 
-[metadata]
 [metadata.runtime]
 url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.1.3/sf-fx-runtime-java-runtime-1.1.3-jar-with-dependencies.jar"
 sha256 = "b8e17b6ee9889304cbd07958f86ac067cb58c7f6bdd324a87133d377f670adb5"
+
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-jvm-function-invoker"
+image = { repository = "docker.io/heroku/buildpack-jvm-function-invoker" }

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#603](https://github.com/heroku/buildpacks-jvm/pull/603))
+
 ## [3.2.1] - 2023-10-19
 
 ### Changed

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -3,10 +3,10 @@ api = "0.9"
 [buildpack]
 id = "heroku/jvm"
 version = "3.2.1"
-name = "Heroku OpenJDK Buildpack"
+name = "Heroku OpenJDK"
 homepage = "https://github.com/heroku/buildpacks-jvm"
-description = "Official Heroku buildpack for installing OpenJDK"
-keywords = ["java", "jvm", "jdk", "openjdk"]
+description = "Heroku's OpenJDK buildpack. A component of the 'heroku/java' and 'heroku/scala' buildpacks."
+keywords = ["openjdk", "heroku"]
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -17,10 +17,9 @@ id = "heroku-20"
 [[stacks]]
 id = "heroku-22"
 
-[metadata]
 [metadata.heroku-metrics-agent]
 url = "https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/4.0.1/heroku-java-metrics-agent-4.0.1.jar"
 sha256 = "9a718680e4a93f93a8755b20fb21cc541e5c2692acc9da27c667530f48a716db"
-[metadata.release]
+
 [metadata.release.image]
-repository = "docker.io/heroku/buildpack-jvm"
+image = { repository = "docker.io/heroku/buildpack-jvm" }

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#603](https://github.com/heroku/buildpacks-jvm/pull/603))
+
 ## [3.2.1] - 2023-10-19
 
 - No changes.

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -3,11 +3,11 @@ api = "0.9"
 [buildpack]
 id = "heroku/maven"
 version = "3.2.1"
-name = "Maven"
-clear-env = true
+name = "Heroku Maven"
 homepage = "https://github.com/heroku/buildpacks-jvm"
-description = "Official Heroku buildpack for Maven applications."
-keywords = ["java", "maven", "mvn"]
+description = "Heroku's Maven buildpack. A component of the 'heroku/java' buildpack."
+keywords = ["maven", "heroku"]
+clear-env = true
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -17,10 +17,11 @@ id = "*"
 
 [metadata]
 default-version = "3.9.4"
+
 [metadata.tarballs]
 [metadata.tarballs."3.9.4"]
 url = "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.tar.gz"
 sha256 = "ff66b70c830a38d331d44f6c25a37b582471def9a161c93902bac7bea3098319"
+
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-maven"
+image = { repository = "docker.io/heroku/buildpack-maven" }

--- a/buildpacks/sbt/CHANGELOG.md
+++ b/buildpacks/sbt/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#603](https://github.com/heroku/buildpacks-jvm/pull/603))
+
 ## [3.2.1] - 2023-10-19
 
 - No changes.

--- a/buildpacks/sbt/buildpack.toml
+++ b/buildpacks/sbt/buildpack.toml
@@ -3,11 +3,11 @@ api = "0.9"
 [buildpack]
 id = "heroku/sbt"
 version = "3.2.1"
-name = "sbt"
-clear-env = true
+name = "Heroku sbt"
 homepage = "https://github.com/heroku/buildpacks-jvm"
-description = "Official Heroku buildpack for sbt applications."
-keywords = ["java", "scala", "sbt"]
+description = "Heroku's sbt buildpack. A component of the 'heroku/scala' buildpack."
+keywords = ["sbt", "heroku"]
+clear-env = true
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -15,7 +15,5 @@ type = "BSD-3-Clause"
 [[stacks]]
 id = "*"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-sbt"
+image = { repository = "docker.io/heroku/buildpack-sbt" }

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#603](https://github.com/heroku/buildpacks-jvm/pull/603))
+
 ## [3.2.1] - 2023-10-19
 
 ### Changed

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -3,9 +3,9 @@ api = "0.9"
 [buildpack]
 id = "heroku/java-function"
 version = "3.2.1"
-name = "Java Function"
+name = "Salesforce Java Function"
 homepage = "https://github.com/heroku/buildpacks-jvm"
-keywords = ["java", "function"]
+description = "Salesforce's buildpack for Java Functions."
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -24,7 +24,5 @@ version = "3.2.1"
 id = "heroku/jvm-function-invoker"
 version = "3.2.1"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-java-function"
+image = { repository = "docker.io/heroku/buildpack-java-function" }

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#603](https://github.com/heroku/buildpacks-jvm/pull/603))
+
 ## [3.2.1] - 2023-10-19
 
 ### Changed

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -3,10 +3,10 @@ api = "0.9"
 [buildpack]
 id = "heroku/java"
 version = "3.2.1"
-name = "Java"
+name = "Heroku Java"
 homepage = "https://github.com/heroku/buildpacks-jvm"
-description = "Official Heroku buildpack for Java applications."
-keywords = ["java"]
+description = "Heroku's buildpack for Java applications."
+keywords = ["java", "openjdk", "maven", "gradle", "heroku"]
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -41,7 +41,5 @@ id = "heroku/procfile"
 version = "2.0.1"
 optional = true
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-java"
+image = { repository = "docker.io/heroku/buildpack-java" }

--- a/meta-buildpacks/scala/CHANGELOG.md
+++ b/meta-buildpacks/scala/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#603](https://github.com/heroku/buildpacks-jvm/pull/603))
+
 ## [3.2.1] - 2023-10-19
 
 ### Changed

--- a/meta-buildpacks/scala/buildpack.toml
+++ b/meta-buildpacks/scala/buildpack.toml
@@ -3,10 +3,10 @@ api = "0.9"
 [buildpack]
 id = "heroku/scala"
 version = "3.2.1"
-name = "Scala"
+name = "Heroku Scala"
 homepage = "https://github.com/heroku/buildpacks-jvm"
-description = "Official Heroku buildpack for Scala applications."
-keywords = ["scala"]
+description = "Heroku's buildpack for Scala applications."
+keywords = ["scala", "openjdk", "sbt", "heroku"]
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
@@ -26,7 +26,5 @@ id = "heroku/procfile"
 version = "2.0.1"
 optional = true
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-scala"
+image = { repository = "docker.io/heroku/buildpack-scala" }


### PR DESCRIPTION
Adjusts the buildpack `name`, `description` and `keywords` in the `buildpack.toml` of all buildpacks to match the style discussed in: https://github.com/heroku/cnb-builder-images/issues/408

The `keywords` field has intentionally been omitted from the functions buildpacks since they are EOL and so don't want to be made more discoverable. (The CNB registry doesn't currently ingest/display the keywords currently, but may in the future.)

Lastly, I've cleaned up the `[metadata]` table/subtables to match the concise style used by the Procfile and Python CNBs.