### PR TITLE
Update libcnb from 0.14.0 to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "buildpack-heroku-jvm"
 version = "0.0.0"
 dependencies = [
@@ -157,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -359,6 +369,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "gradle"
 version = "0.0.0"
 dependencies = [
@@ -395,6 +418,23 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -453,10 +493,11 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libcnb"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5132851c82d808e6b42edd1cc9e7cb9b16b0274c325b25fdb42660fae9b2e88b"
+checksum = "460e3b9d5b51eee9b9eb154e8bece15b77fff8b287457c09699a609c977003c9"
 dependencies = [
+ "libcnb-common",
  "libcnb-data",
  "libcnb-proc-macros",
  "serde",
@@ -465,10 +506,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "libcnb-data"
-version = "0.14.0"
+name = "libcnb-common"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bed8b0f2676aebeb216a7f7872151fbf74ff3706c7027449573c03c9d7f3393"
+checksum = "53c4c77089f294316c1d8a285d0ed9973e796a2653c676b22b3f7703d73aa828"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "libcnb-data"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f35c4af3b47b67257263f0504897cf4db263b407b3e367971fc0b60ada69ce2"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -480,22 +532,25 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "412f8c3ee7e2fcaff1acd1926a238cac271e86d7258c51038053fac17d85d144"
+checksum = "d5ee4c1ac95fc5f71b0f8901d62644f9d39dad0be9d1a5bf23fae173aaf2a46c"
 dependencies = [
  "cargo_metadata",
+ "ignore",
+ "libcnb-common",
  "libcnb-data",
  "petgraph",
- "toml",
+ "thiserror",
+ "uriparse",
  "which",
 ]
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c715cec438b3a02c3564e9b9c20a78c54b9c71874249bec1e3d45fcd2537cfcf"
+checksum = "5effc8c71a7401899ea2885681b213b779449dc0f581663ea850d9de0718434c"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
@@ -505,13 +560,13 @@ dependencies = [
 
 [[package]]
 name = "libcnb-test"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ee152780ab4ad6e4aca8ec12767c090677294b7aa4ffc1a90633d38b429c9e"
+checksum = "b88d0682a1abd6261f406f52214272c09738ddae239cc5d38159dfa7a53e2e63"
 dependencies = [
- "cargo_metadata",
  "fastrand",
  "fs_extra",
+ "libcnb-common",
  "libcnb-data",
  "libcnb-package",
  "tempfile",
@@ -519,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999689d1a9f8cbea478ae7c4ce6136601e7abe9512ccfc0409f5525949a41457"
+checksum = "2c01b437767257854de9a8011c6f7e265dc6ebc344cc122ffef2464f3e10bfc8"
 dependencies = [
  "crossbeam-utils",
  "flate2",
@@ -772,6 +827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "sbt"
 version = "0.0.0"
 dependencies = [
@@ -937,6 +1001,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,9 +1027,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "2ef75d881185fd2df4a040793927c153d863651108a93c7e17a9e591baa95cc6"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -974,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "380f9e8120405471f7c9ad1860a713ef5ece6a670c7eae39225e477340f32fc4"
 dependencies = [
  "indexmap",
  "serde",
@@ -1066,6 +1140,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ publish = false
 [workspace.dependencies]
 # libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
 # so it's pinned to an exact version to isolate it from lockfile refreshes.
-libcnb = "=0.14.0"
-libcnb-test = "=0.14.0"
-libherokubuildpack = "=0.14.0"
-toml = "0.7"
+libcnb = "=0.15.0"
+libcnb-test = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+toml = "0.8"
 buildpacks-jvm-shared = { path = "shared" }
 buildpacks-jvm-shared-test = { path = "shared-test" }

--- a/buildpacks/gradle/tests/integration/main.rs
+++ b/buildpacks/gradle/tests/integration/main.rs
@@ -13,7 +13,7 @@ mod ux;
 pub(crate) fn default_buildpacks() -> Vec<BuildpackReference> {
     vec![
         BuildpackReference::Other(String::from("heroku/jvm")),
-        BuildpackReference::Crate,
+        BuildpackReference::CurrentCrate,
         // Using an explicit version from Docker Hub to prevent failures when there
         // are multiple Procfile buildpack versions in the builder image.
         BuildpackReference::Other(String::from("docker://docker.io/heroku/procfile-cnb:2.0.1")),

--- a/buildpacks/jvm-function-invoker/tests/integration/smoke.rs
+++ b/buildpacks/jvm-function-invoker/tests/integration/smoke.rs
@@ -13,7 +13,7 @@ fn smoke_test_simple_function() {
         BuildConfig::new(DEFAULT_INTEGRATION_TEST_BUILDER, "test-apps/simple-function").buildpacks([
             BuildpackReference::Other(String::from("heroku/jvm")),
             BuildpackReference::Other(String::from("heroku/maven")),
-            BuildpackReference::Crate,
+            BuildpackReference::CurrentCrate,
         ]),
         |context| {
             context.start_container(

--- a/buildpacks/maven/tests/integration/main.rs
+++ b/buildpacks/maven/tests/integration/main.rs
@@ -29,6 +29,6 @@ pub(crate) fn default_config() -> BuildConfig {
 pub(crate) fn default_buildpacks() -> Vec<BuildpackReference> {
     vec![
         BuildpackReference::Other(String::from("heroku/jvm")),
-        BuildpackReference::Crate,
+        BuildpackReference::CurrentCrate,
     ]
 }

--- a/buildpacks/sbt/tests/integration/main.rs
+++ b/buildpacks/sbt/tests/integration/main.rs
@@ -15,7 +15,7 @@ mod ux;
 pub(crate) fn default_buildpacks() -> Vec<BuildpackReference> {
     vec![
         BuildpackReference::Other(String::from("heroku/jvm")),
-        BuildpackReference::Crate,
+        BuildpackReference::CurrentCrate,
         // Using an explicit version from Docker Hub to prevent failures when there
         // are multiple Procfile buildpack versions in the builder image.
         BuildpackReference::Other(String::from("docker://docker.io/heroku/procfile-cnb:2.0.1")),


### PR DESCRIPTION
This also required updating `toml` to 0.8 to prevent a type mismatch error due to the `jvm-function-invoker` buildpack using `libherokubuildpack::toml::toml_select_value` (which itself  is now using toml 0.8).

https://github.com/heroku/libcnb.rs/releases/tag/v0.15.0
https://github.com/heroku/libcnb.rs/compare/v0.14.0...v0.15.0

GUS-W-14354898.