### PR TITLE
Fix release metadata for `heroku/jvm`

### DIFF
--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -21,5 +21,5 @@ id = "heroku-22"
 url = "https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/4.0.1/heroku-java-metrics-agent-4.0.1.jar"
 sha256 = "9a718680e4a93f93a8755b20fb21cc541e5c2692acc9da27c667530f48a716db"
 
-[metadata.release.image]
+[metadata.release]
 image = { repository = "docker.io/heroku/buildpack-jvm" }


### PR DESCRIPTION
Missed during the regex search and replace used for #603.

GUS-W-14121598.