### PR TITLE
Remove `heroku/procfile` from `heroku/java` and `heroku/scala`

### DIFF
--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `heroku/procfile`, since it's being added directly to the Heroku builder images instead. If you override the Heroku builder images' default buildpack detection order (or use this buildpack with a non-Heroku builder image), you will need to append `heroku/procfile` to your buildpacks list. ([#608](https://github.com/heroku/buildpacks-jvm/pull/608))
+
 ## [3.2.2] - 2023-10-24
 
 ### Changed

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -21,11 +21,6 @@ version = "3.2.2"
 id = "heroku/maven"
 version = "3.2.2"
 
-[[order.group]]
-id = "heroku/procfile"
-version = "2.0.1"
-optional = true
-
 [[order]]
 
 [[order.group]]
@@ -35,11 +30,6 @@ version = "3.2.2"
 [[order.group]]
 id = "heroku/gradle"
 version = "3.2.2"
-
-[[order.group]]
-id = "heroku/procfile"
-version = "2.0.1"
-optional = true
 
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-java" }

--- a/meta-buildpacks/java/package.toml
+++ b/meta-buildpacks/java/package.toml
@@ -9,6 +9,3 @@ uri = "libcnb:heroku/maven"
 
 [[dependencies]]
 uri = "libcnb:heroku/gradle"
-
-[[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"

--- a/meta-buildpacks/scala/CHANGELOG.md
+++ b/meta-buildpacks/scala/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `heroku/procfile`, since it's being added directly to the Heroku builder images instead. If you override the Heroku builder images' default buildpack detection order (or use this buildpack with a non-Heroku builder image), you will need to append `heroku/procfile` to your buildpacks list. ([#608](https://github.com/heroku/buildpacks-jvm/pull/608))
+
 ## [3.2.2] - 2023-10-24
 
 ### Changed

--- a/meta-buildpacks/scala/buildpack.toml
+++ b/meta-buildpacks/scala/buildpack.toml
@@ -21,10 +21,5 @@ version = "3.2.2"
 id = "heroku/sbt"
 version = "3.2.2"
 
-[[order.group]]
-id = "heroku/procfile"
-version = "2.0.1"
-optional = true
-
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-scala" }

--- a/meta-buildpacks/scala/package.toml
+++ b/meta-buildpacks/scala/package.toml
@@ -6,6 +6,3 @@ uri = "libcnb:heroku/jvm"
 
 [[dependencies]]
 uri = "libcnb:heroku/sbt"
-
-[[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"


### PR DESCRIPTION
Previously the `heroku/procfile` buildpack was included within the `heroku/java` and `heroku/scala` composite buildpacks.

Whilst this is convenient (it saves having to add the Procfile CNB manually), this approach has a number of issues:
- If an app uses multiple languages (eg `heroku/nodejs` and `heroku/java`), the Procfile CNB will end up being run multiple times, and potentially with different versions of the Procfile buildpack.
- It means multiple places need updating after Procfile CNB releases, and means the builder image can end up containing several different versions of the Procfile buildpack.

After this change, the `heroku/procfile` CNB is no longer included in the `heroku/java` and `heroku/scala` composite buildpacks, and instead will be included in the Heroku builder image order grouping (added in the PR that releases this change into the builder).

This matches the approach already used by the Go, Python, PHP and Ruby buildpacks.

Any app that sets a custom buildpack order in their `project.toml` (rather than relying on the default buildpack order in the Heroku builder image), or uses a non-Heroku builder (that does not similarly choose to add the Procfile to the builder) will need to explicitly add the `heroku/procfile` buildpack to the end of the buildpacks list in their `project.toml`.

**Since this is a breaking change, the buildpack major version number should be bumped for release.**

See also:
https://github.com/heroku/buildpacks-nodejs/pull/696

GUS-W-14356096.