### PR TITLE
Switch away from workspace-defined dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,5 @@ edition = "2021"
 publish = false
 
 [workspace.dependencies]
-# libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
-# so it's pinned to an exact version to isolate it from lockfile refreshes.
-libcnb = "=0.15.0"
-libcnb-test = "=0.15.0"
-libherokubuildpack = "=0.15.0"
-toml = "0.8"
 buildpacks-jvm-shared = { path = "shared" }
 buildpacks-jvm-shared-test = { path = "shared-test" }

--- a/buildpacks/gradle/Cargo.toml
+++ b/buildpacks/gradle/Cargo.toml
@@ -6,13 +6,13 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-libcnb.workspace = true
-libherokubuildpack.workspace = true
-serde = { version = "1", features = ["derive"] }
 buildpacks-jvm-shared.workspace = true
-nom = "7"
 indoc = "2"
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+nom = "7"
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-libcnb-test.workspace = true
 buildpacks-jvm-shared-test.workspace = true
+libcnb-test = "=0.15.0"

--- a/buildpacks/jvm-function-invoker/Cargo.toml
+++ b/buildpacks/jvm-function-invoker/Cargo.toml
@@ -7,15 +7,15 @@ publish.workspace = true
 
 [dependencies]
 indoc = "2"
-libcnb.workspace = true
-libherokubuildpack.workspace = true
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
 serde = "1"
 thiserror = "1"
-toml.workspace = true
+toml = "0.8"
 
 [dev-dependencies]
-tempfile = "3"
-libcnb-test.workspace = true
-ureq = "2"
 base64 = "0.21"
 buildpacks-jvm-shared-test.workspace = true
+libcnb-test = "=0.15.0"
+tempfile = "3"
+ureq = "2"

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -9,13 +9,13 @@ publish.workspace = true
 buildpacks-jvm-shared.workspace = true
 fs_extra = "1"
 indoc = "2"
-libcnb.workspace = true
-libherokubuildpack.workspace = true
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"
 ureq = "2"
 url = "2"
 
 [dev-dependencies]
-libcnb-test.workspace = true
 buildpacks-jvm-shared-test.workspace = true
+libcnb-test = "=0.15.0"

--- a/buildpacks/maven/Cargo.toml
+++ b/buildpacks/maven/Cargo.toml
@@ -9,8 +9,8 @@ publish.workspace = true
 buildpacks-jvm-shared.workspace = true
 flate2 = "1"
 indoc = "2"
-libcnb.workspace = true
-libherokubuildpack.workspace = true
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 shell-words = "1"
@@ -18,6 +18,6 @@ tar = "0.4"
 tempfile = "3"
 
 [dev-dependencies]
-libcnb-test.workspace = true
-java-properties = "2"
 buildpacks-jvm-shared-test.workspace = true
+java-properties = "2"
+libcnb-test = "=0.15.0"

--- a/buildpacks/sbt/Cargo.toml
+++ b/buildpacks/sbt/Cargo.toml
@@ -6,18 +6,18 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-libcnb.workspace = true
-libherokubuildpack.workspace = true
+buildpacks-jvm-shared.workspace = true
 indoc = "2"
 java-properties = "2"
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
+shell-words = "1"
 tempfile = "3"
 thiserror = "1"
-semver = { version = "1", features = ["serde"] }
-shell-words = "1"
-buildpacks-jvm-shared.workspace = true
 
 [dev-dependencies]
-libcnb-test.workspace = true
 buildpacks-jvm-shared-test.workspace = true
+libcnb-test = "=0.15.0"
 ureq = "2"

--- a/shared-test/Cargo.toml
+++ b/shared-test/Cargo.toml
@@ -6,6 +6,6 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-ureq = "2"
 exponential-backoff = "1"
-libcnb-test.workspace = true
+libcnb-test = "=0.15.0"
+ureq = "2"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -7,6 +7,6 @@ publish.workspace = true
 
 [dependencies]
 indoc = "2"
-libherokubuildpack.workspace = true
-libcnb.workspace = true
 java-properties = "2"
+libcnb = "=0.15.0"
+libherokubuildpack = "=0.15.0"


### PR DESCRIPTION
Both Dependabot and `cargo-edit`'s `cargo upgrade` don't seem to handle dependencies being specified in the Cargo workspace `Cargo.toml` and inherited by individual crates very well.

As such, this switches back to specifying those dependencies explicitly in each crate. Dependabot always updates dependencies across all crates, so they will still stay in sync.

Hopefully this change will fix:

```
updater | 2023/11/17 15:48:21 INFO <job_751330580> No update possible for libcnb 0.15.0
```

Seen in:
https://github.com/heroku/buildpacks-jvm/network/updates/751330580

I've left the local shared crate dependencies as workspace-defined, since Dependabot or `cargo-edit` doesn't need to update those, since they are path-only dependencies.

Lastly, the lists of dependencies have been sorted alphabetically.