### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,6 @@ dependencies = [
  "serde",
  "shell-words",
  "tempfile",
- "thiserror",
  "ureq",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,18 @@ members = [
 
 [workspace.package]
 version = "0.0.0"
-rust-version = "1.66"
+rust-version = "1.74"
 edition = "2021"
 publish = false
+
+[workspace.lints.rust]
+unused_crate_dependencies = "warn"
+
+[workspace.lints.clippy]
+pedantic = "warn"
+enum_variant_names = "allow"
+missing_errors_doc = "allow"
+module_name_repetitions = "allow"
 
 [workspace.dependencies]
 buildpacks-jvm-shared = { path = "shared" }

--- a/buildpacks/gradle/Cargo.toml
+++ b/buildpacks/gradle/Cargo.toml
@@ -5,6 +5,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildpacks-jvm-shared.workspace = true
 indoc = "2"

--- a/buildpacks/gradle/src/main.rs
+++ b/buildpacks/gradle/src/main.rs
@@ -1,11 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
-
 use crate::config::GradleBuildpackConfig;
 use crate::detect::is_gradle_project_directory;
 use crate::errors::on_error_gradle_buildpack;

--- a/buildpacks/gradle/tests/integration/main.rs
+++ b/buildpacks/gradle/tests/integration/main.rs
@@ -3,7 +3,10 @@
 //! - Reduce required disk space
 //! - Increase parallelism
 //!
-//! See: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications
+//! See: <https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications>
+
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb_test::BuildpackReference;
 

--- a/buildpacks/gradle/tests/integration/ux.rs
+++ b/buildpacks/gradle/tests/integration/ux.rs
@@ -18,7 +18,7 @@ fn test_unsupported_java_version() {
             &dir,
             &HashMap::from([(String::from("java.runtime.version"), String::from("7"))]),
         )
-        .unwrap()
+        .unwrap();
     })
     .to_owned();
 

--- a/buildpacks/jvm-function-invoker/Cargo.toml
+++ b/buildpacks/jvm-function-invoker/Cargo.toml
@@ -5,6 +5,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 indoc = "2"
 libcnb = "=0.16.0"

--- a/buildpacks/jvm-function-invoker/src/main.rs
+++ b/buildpacks/jvm-function-invoker/src/main.rs
@@ -1,12 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// Re-disable pedantic lints that are too noisy/unwanted.
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::enum_variant_names)]
-
 use crate::common::project_toml_salesforce_type_is_function;
 use crate::error::{handle_buildpack_error, JvmFunctionInvokerBuildpackError};
 use crate::layers::bundle::BundleLayer;

--- a/buildpacks/jvm-function-invoker/tests/integration/main.rs
+++ b/buildpacks/jvm-function-invoker/tests/integration/main.rs
@@ -3,6 +3,9 @@
 //! - Reduce required disk space
 //! - Increase parallelism
 //!
-//! See: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications
+//! See: <https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications>
+
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 mod smoke;

--- a/buildpacks/jvm-function-invoker/tests/integration/smoke.rs
+++ b/buildpacks/jvm-function-invoker/tests/integration/smoke.rs
@@ -46,7 +46,7 @@ fn smoke_test_simple_function() {
                 },
             );
         },
-    )
+    );
 }
 
 const PORT: u16 = 8080;

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -5,6 +5,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildpacks-jvm-shared.workspace = true
 fs_extra = "1"

--- a/buildpacks/jvm/src/bin/heroku_database_env_var_rewrite.rs
+++ b/buildpacks/jvm/src/bin/heroku_database_env_var_rewrite.rs
@@ -1,15 +1,11 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb::data::exec_d::ExecDProgramOutputKey;
 use libcnb::exec_d::write_exec_d_program_output;
 use std::collections::HashMap;
 use url::Url;
 
-#[allow(clippy::missing_panics_doc)]
 pub(crate) fn main() {
     write_exec_d_program_output(
         jvm_env_vars_for_env(&std::env::vars().collect())

--- a/buildpacks/jvm/src/bin/heroku_dynamic_jvm_opts.rs
+++ b/buildpacks/jvm/src/bin/heroku_dynamic_jvm_opts.rs
@@ -1,8 +1,5 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb::data::exec_d::ExecDProgramOutputKey;
 use libcnb::data::exec_d_program_output_key;

--- a/buildpacks/jvm/src/bin/heroku_metrics_agent_setup.rs
+++ b/buildpacks/jvm/src/bin/heroku_metrics_agent_setup.rs
@@ -1,8 +1,5 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb::data::exec_d::ExecDProgramOutputKey;
 use libcnb::data::exec_d_program_output_key;

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -1,11 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
-
 mod constants;
 mod errors;
 mod layers;

--- a/buildpacks/jvm/tests/integration/main.rs
+++ b/buildpacks/jvm/tests/integration/main.rs
@@ -3,6 +3,9 @@
 //! - Reduce required disk space
 //! - Increase parallelism
 //!
-//! See: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications
+//! See: <https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications>
+
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 mod versions;

--- a/buildpacks/jvm/tests/integration/versions.rs
+++ b/buildpacks/jvm/tests/integration/versions.rs
@@ -11,7 +11,7 @@ fn test_openjdk_8_distribution_heroku_20() {
                 "openjdk version \"1.8.0_392-heroku\""
             );
         },
-    )
+    );
 }
 
 #[test]
@@ -25,5 +25,5 @@ fn test_openjdk_8_distribution_heroku_22() {
                 "openjdk version \"1.8.0_392\""
             );
         },
-    )
+    );
 }

--- a/buildpacks/maven/Cargo.toml
+++ b/buildpacks/maven/Cargo.toml
@@ -5,6 +5,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildpacks-jvm-shared.workspace = true
 flate2 = "1"

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -1,11 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
-
 use crate::errors::on_error_maven_buildpack;
 use crate::framework::DefaultAppProcessError;
 use crate::layer::maven::MavenLayer;

--- a/buildpacks/maven/tests/integration/automatic_process_type.rs
+++ b/buildpacks/maven/tests/integration/automatic_process_type.rs
@@ -16,5 +16,5 @@ fn spring_boot_process_type() {
         |context| {
             start_container_assert_basic_http_response(&context, "Hello from Spring Boot!");
         },
-    )
+    );
 }

--- a/buildpacks/maven/tests/integration/main.rs
+++ b/buildpacks/maven/tests/integration/main.rs
@@ -3,7 +3,10 @@
 //! - Reduce required disk space
 //! - Increase parallelism
 //!
-//! See: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications
+//! See: <https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications>
+
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use buildpacks_jvm_shared_test::DEFAULT_INTEGRATION_TEST_BUILDER;
 use libcnb_test::{BuildConfig, BuildpackReference};

--- a/buildpacks/maven/tests/integration/polyglot.rs
+++ b/buildpacks/maven/tests/integration/polyglot.rs
@@ -14,5 +14,5 @@ fn polyglot_maven_app() {
         |context| {
             assert_contains!(context.pack_stdout, "[INFO] BUILD SUCCESS");
         },
-    )
+    );
 }

--- a/buildpacks/maven/tests/integration/settings_xml.rs
+++ b/buildpacks/maven/tests/integration/settings_xml.rs
@@ -48,7 +48,7 @@ fn maven_settings_path() {
     TestRunner::default().build(
         default_config()
             .app_dir_preprocessor(move |dir| {
-                write_settings_xml(dir.join(settings_xml_filename), settings_xml_test_value)
+                write_settings_xml(dir.join(settings_xml_filename), settings_xml_test_value);
             })
             .env("MAVEN_SETTINGS_PATH", settings_xml_filename),
         |context| {
@@ -71,7 +71,7 @@ fn maven_settings_path_and_settings_url() {
     TestRunner::default().build(
         default_config()
             .app_dir_preprocessor(move |dir| {
-                write_settings_xml(dir.join(settings_xml_filename), settings_xml_test_value)
+                write_settings_xml(dir.join(settings_xml_filename), settings_xml_test_value);
             })
             .env("MAVEN_SETTINGS_PATH", settings_xml_filename)
             .env("MAVEN_SETTINGS_URL", SETTINGS_XML_URL),
@@ -96,7 +96,7 @@ fn maven_settings_xml_in_app_root() {
     TestRunner::default().build(
         // Note that there is no MAVEN_SETTINGS_PATH here
         default_config().app_dir_preprocessor(move |dir| {
-            write_settings_xml(dir.join(settings_xml_filename), settings_xml_test_value)
+            write_settings_xml(dir.join(settings_xml_filename), settings_xml_test_value);
         }),
         |context| {
             assert_contains!(

--- a/buildpacks/maven/tests/integration/versions.rs
+++ b/buildpacks/maven/tests/integration/versions.rs
@@ -11,7 +11,7 @@ fn with_wrapper() {
             assert_contains!(context.pack_stdout, "Maven wrapper detected, skipping installation.");
             assert_contains!(context.pack_stdout, "$ ./mvnw");
             assert_contains!(context.pack_stdout, &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {SIMPLE_HTTP_SERVICE_MAVEN_WRAPPER_VERSION}"));
-        })
+        });
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn with_wrapper_and_system_properties() {
     TestRunner::default().build(
         default_config().app_dir_preprocessor(|path| {
             remove_maven_wrapper(&path);
-            set_maven_version_app_dir_preprocessor(DEFAULT_MAVEN_VERSION, &path)
+            set_maven_version_app_dir_preprocessor(DEFAULT_MAVEN_VERSION, &path);
         }),
         |context| {
             assert_contains!(
@@ -33,7 +33,7 @@ fn with_wrapper_and_system_properties() {
                 &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {DEFAULT_MAVEN_VERSION}")
             );
         },
-    )
+    );
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn with_wrapper_and_unknown_system_properties() {
                 assert_contains!(context.pack_stderr, "[Error: Unsupported Maven version]");
                 assert_contains!(context.pack_stderr, &format!("You have defined an unsupported Maven version ({UNKNOWN_MAVEN_VERSION}) in the system.properties file."));
             },
-        )
+        );
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn without_wrapper_and_without_system_properties() {
                 &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {DEFAULT_MAVEN_VERSION}")
             );
         },
-    )
+    );
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn without_wrapper_and_unknown_system_properties() {
                 assert_contains!(context.pack_stderr, "[Error: Unsupported Maven version]");
                 assert_contains!(context.pack_stderr, &format!("You have defined an unsupported Maven version ({UNKNOWN_MAVEN_VERSION}) in the system.properties file."));
             },
-        )
+        );
 }
 
 #[test]
@@ -101,11 +101,11 @@ fn without_wrapper_and_maven_3_9_4_system_properties() {
                 "[BUILDPACK INTEGRATION TEST - MAVEN VERSION] 3.9.4"
             );
         },
-    )
+    );
 }
 
 fn remove_maven_wrapper(path: &Path) {
-    std::fs::remove_file(path.join("mvnw")).unwrap()
+    std::fs::remove_file(path.join("mvnw")).unwrap();
 }
 
 fn set_maven_version_app_dir_preprocessor(version: &str, path: &Path) {

--- a/buildpacks/sbt/Cargo.toml
+++ b/buildpacks/sbt/Cargo.toml
@@ -5,6 +5,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildpacks-jvm-shared.workspace = true
 indoc = "2"
@@ -14,10 +17,9 @@ libherokubuildpack = "=0.16.0"
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 shell-words = "1"
-tempfile = "3"
-thiserror = "1"
 
 [dev-dependencies]
 buildpacks-jvm-shared-test.workspace = true
 libcnb-test = "=0.16.0"
+tempfile = "3"
 ureq = "2"

--- a/buildpacks/sbt/src/configuration.rs
+++ b/buildpacks/sbt/src/configuration.rs
@@ -12,7 +12,6 @@ pub(crate) struct SbtBuildpackConfiguration {
 }
 
 #[derive(Debug)]
-#[allow(clippy::enum_variant_names)]
 pub(crate) enum ReadSbtBuildpackConfigurationError {
     InvalidPreTaskList(shell_words::ParseError),
     InvalidTaskList(shell_words::ParseError),

--- a/buildpacks/sbt/src/layers/sbt_extras.rs
+++ b/buildpacks/sbt/src/layers/sbt_extras.rs
@@ -89,7 +89,6 @@ fn get_layer_env_scope(available_at_launch: bool) -> Scope {
 }
 
 #[derive(Debug)]
-#[allow(clippy::enum_variant_names)]
 pub(crate) enum SbtExtrasLayerError {
     CouldNotWriteScript(std::io::Error),
     CouldNotSetPermissions(std::io::Error),

--- a/buildpacks/sbt/src/main.rs
+++ b/buildpacks/sbt/src/main.rs
@@ -1,9 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
-
 mod configuration;
 mod detect;
 mod errors;
@@ -30,6 +24,15 @@ use libherokubuildpack::error::on_error as on_buildpack_error;
 use libherokubuildpack::log::{log_header, log_info};
 use std::io::{stderr, stdout};
 use std::process::Command;
+
+#[cfg(test)]
+use buildpacks_jvm_shared_test as _;
+#[cfg(test)]
+use libcnb_test as _;
+#[cfg(test)]
+use tempfile as _;
+#[cfg(test)]
+use ureq as _;
 
 pub(crate) struct SbtBuildpack;
 

--- a/buildpacks/sbt/tests/integration/main.rs
+++ b/buildpacks/sbt/tests/integration/main.rs
@@ -3,7 +3,10 @@
 //! - Reduce required disk space
 //! - Increase parallelism
 //!
-//! See: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications
+//! See: <https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications>
+
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use libcnb_test::BuildpackReference;
 

--- a/shared-test/Cargo.toml
+++ b/shared-test/Cargo.toml
@@ -5,6 +5,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 exponential-backoff = "1"
 libcnb-test = "=0.16.0"

--- a/shared-test/src/lib.rs
+++ b/shared-test/src/lib.rs
@@ -1,13 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
-// This crate is for internal use only, we don't always need error docs.
-#![allow(clippy::missing_errors_doc)]
-
 use libcnb_test::{
     assert_contains, BuildConfig, BuildpackReference, ContainerConfig, TestContext, TestRunner,
 };
@@ -75,7 +65,6 @@ where
 /// builds the app again to ensure that any caching logic does not break subsequent builds. After
 /// each build, an HTTP request is made to the resulting container, asserting that the given string
 /// is present in the response.
-#[allow(clippy::missing_panics_doc)]
 pub fn smoke_test<P, B>(
     builder_name: &str,
     app_dir: P,

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,6 +5,9 @@ rust-version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 indoc = "2"
 java-properties = "2"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,13 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
-// This crate is for internal use only, we don't always need error docs.
-#![allow(clippy::missing_errors_doc)]
-
 pub mod env;
 pub mod fs;
 pub mod log;


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in `Cargo.toml` across whole crates/workspaces:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section
https://doc.rust-lang.org/stable/cargo/reference/workspaces.html#the-lints-table

This reduces the boilerplate, and the chance that we forget to enable lints in some targets. The only thing we need to remember is to add the `[lints] workspace = true` to any new crates in the future.

Making this switch exposed a few places where lints weren't enabled and issues had been missed, which have been fixed now.

Since this feature requires Rust 1.74, the MSRV has also been bumped (however, libcnb 0.16.0 already requires Rust 1.74, so in practice this is a no-op).

GUS-W-14523834.