### PR TITLE
Simplify Cargo metadata for `publish = false` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,8 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.0"
-rust-version = "1.74"
+rust-version = "1.75"
 edition = "2021"
-publish = false
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/buildpacks/gradle/Cargo.toml
+++ b/buildpacks/gradle/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "gradle"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/jvm-function-invoker/Cargo.toml
+++ b/buildpacks/jvm-function-invoker/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "buildpack-heroku-jvm-function-invoker"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "buildpack-heroku-jvm"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/maven/Cargo.toml
+++ b/buildpacks/maven/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "buildpack-heroku-maven"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/buildpacks/sbt/Cargo.toml
+++ b/buildpacks/sbt/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "sbt"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/shared-test/Cargo.toml
+++ b/shared-test/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "buildpacks-jvm-shared-test"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "buildpacks-jvm-shared"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28
https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

GUS-W-14821120.