### PR TITLE
Add Gradle init script support

### DIFF
--- a/buildpacks/gradle/CHANGELOG.md
+++ b/buildpacks/gradle/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for [Gradle init scripts](https://docs.gradle.org/8.5/userguide/init_scripts.html). Kotlin and/or Groovy init scripts in `$APP_DIR/.heroku/gradle/init.d` will be automatically picked up by the buildpack and passed to Gradle. ([#629](https://github.com/heroku/buildpacks-jvm/pull/629))
+
 ## [4.0.2] - 2023-12-05
 
 - No changes.

--- a/buildpacks/gradle/README.md
+++ b/buildpacks/gradle/README.md
@@ -31,5 +31,9 @@ Allows other buildpacks to depend on a compiled JVM application.
 #### `GRADLE_TASK`
 Allows overriding the Gradle task used during the build process. The default task is `stage`.
 
+### Buildpack Specific Directories
+#### `$APP_DIR/.heroku/gradle/init.d`
+Allows usage of [Gradle init scripts](https://docs.gradle.org/8.5/userguide/init_scripts.html). Kotlin and/or Groovy init scripts in this directory will be automatically picked up by the buildpack and passed to Gradle.
+
 ## License
 See [LICENSE](../../LICENSE) file.

--- a/buildpacks/gradle/src/gradle_command/daemon.rs
+++ b/buildpacks/gradle/src/gradle_command/daemon.rs
@@ -1,16 +1,19 @@
+use crate::gradle_command::init::gradle_init_script_args;
 use crate::gradle_command::GradleCommandError;
 use crate::GRADLE_TASK_NAME_HEROKU_START_DAEMON;
 use libcnb::Env;
 use libherokubuildpack::command::CommandExt;
 use std::io::{stderr, stdout};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub(crate) fn start(
     gradle_wrapper_executable_path: &Path,
     gradle_env: &Env,
+    gradle_init_scripts: &[PathBuf],
 ) -> Result<(), GradleCommandError<()>> {
     let output = Command::new(gradle_wrapper_executable_path)
+        .args(gradle_init_script_args(gradle_init_scripts))
         .args([
             // Fixes an issue when when running under Apple Rosetta emulation
             "-Djdk.lang.Process.launchMechanism=vfork",

--- a/buildpacks/gradle/src/gradle_command/dependency_report.rs
+++ b/buildpacks/gradle/src/gradle_command/dependency_report.rs
@@ -1,16 +1,19 @@
+use crate::gradle_command::init::gradle_init_script_args;
 use crate::gradle_command::GradleCommandError;
 use libcnb::Env;
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub(crate) fn dependency_report(
     app_dir: &Path,
     env: &Env,
+    gradle_init_scripts: &[PathBuf],
 ) -> Result<GradleDependencyReport, GradleCommandError<()>> {
     let output = Command::new(app_dir.join("gradlew"))
         .current_dir(app_dir)
         .envs(env)
+        .args(gradle_init_script_args(gradle_init_scripts))
         .args(["--quiet", "dependencies"])
         .output()
         .map_err(GradleCommandError::Io)?;

--- a/buildpacks/gradle/src/gradle_command/init.rs
+++ b/buildpacks/gradle/src/gradle_command/init.rs
@@ -1,0 +1,31 @@
+use buildpacks_jvm_shared::fs::list_directory_contents;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn find_init_scripts(app_dir: &Path) -> Vec<PathBuf> {
+    list_directory_contents(app_dir.join(".heroku/gradle/init.d"))
+        .map(|paths| {
+            paths
+                .filter(|path| {
+                    GRADLE_INIT_SCRIPT_SUFFIXES
+                        .iter()
+                        .any(|suffix| path.to_string_lossy().ends_with(suffix))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub(crate) fn gradle_init_script_args(init_script_paths: &[PathBuf]) -> Vec<String> {
+    init_script_paths
+        .iter()
+        .flat_map(|init_script_path| {
+            vec![
+                String::from("--init-script"),
+                init_script_path.to_string_lossy().into_owned(),
+            ]
+        })
+        .collect()
+}
+
+// https://docs.gradle.org/8.5/userguide/init_scripts.html#sec:using_an_init_script
+const GRADLE_INIT_SCRIPT_SUFFIXES: [&str; 2] = [".gradle", ".init.gradle.kts"];

--- a/buildpacks/gradle/src/gradle_command/mod.rs
+++ b/buildpacks/gradle/src/gradle_command/mod.rs
@@ -1,5 +1,6 @@
 mod daemon;
 mod dependency_report;
+pub(crate) mod init;
 mod tasks;
 
 pub(crate) use daemon::start as start_daemon;

--- a/buildpacks/gradle/src/gradle_command/tasks.rs
+++ b/buildpacks/gradle/src/gradle_command/tasks.rs
@@ -1,16 +1,19 @@
+use crate::gradle_command::init::gradle_init_script_args;
 use crate::gradle_command::{run_gradle_command, GradleCommandError};
 use libcnb::Env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub(crate) fn tasks(
     current_dir: &Path,
     env: &Env,
+    gradle_init_scripts: &[PathBuf],
 ) -> Result<Tasks, GradleCommandError<nom::error::Error<String>>> {
     run_gradle_command(
         Command::new(current_dir.join("gradlew"))
             .current_dir(current_dir)
             .envs(env)
+            .args(gradle_init_script_args(gradle_init_scripts))
             .args(["--quiet", "tasks"]),
         |stdout, _stderr| {
             parser::parse(stdout)

--- a/buildpacks/gradle/src/main.rs
+++ b/buildpacks/gradle/src/main.rs
@@ -2,6 +2,7 @@ use crate::config::GradleBuildpackConfig;
 use crate::detect::is_gradle_project_directory;
 use crate::errors::on_error_gradle_buildpack;
 use crate::framework::{detect_framework, Framework};
+use crate::gradle_command::init::{find_init_scripts, gradle_init_script_args};
 use crate::gradle_command::GradleCommandError;
 use crate::layers::gradle_home::GradleHomeLayer;
 use crate::GradleBuildpackError::{GradleBuildIoError, GradleBuildUnexpectedStatusError};
@@ -77,6 +78,8 @@ impl Buildpack for GradleBuildpack {
         log_header("Gradle Buildpack");
         let buildpack_config = GradleBuildpackConfig::from(&context);
 
+        let gradle_init_scripts = find_init_scripts(&context.app_dir);
+
         let gradle_wrapper_executable_path = Some(context.app_dir.join("gradlew"))
             .filter(|path| path.exists())
             .ok_or(GradleBuildpackError::GradleWrapperNotFound)?;
@@ -91,16 +94,22 @@ impl Buildpack for GradleBuildpack {
         );
 
         log_header("Starting Gradle Daemon");
-        gradle_command::start_daemon(&gradle_wrapper_executable_path, &gradle_env)
-            .map_err(GradleBuildpackError::StartGradleDaemonError)?;
+        gradle_command::start_daemon(
+            &gradle_wrapper_executable_path,
+            &gradle_env,
+            &gradle_init_scripts,
+        )
+        .map_err(GradleBuildpackError::StartGradleDaemonError)?;
 
-        let project_tasks = gradle_command::tasks(&context.app_dir, &gradle_env)
-            .map_err(|command_error| command_error.map_parse_error(|_| ()))
-            .map_err(GradleBuildpackError::GetTasksError)?;
+        let project_tasks =
+            gradle_command::tasks(&context.app_dir, &gradle_env, &gradle_init_scripts)
+                .map_err(|command_error| command_error.map_parse_error(|_| ()))
+                .map_err(GradleBuildpackError::GetTasksError)?;
 
-        let detected_framework = gradle_command::dependency_report(&context.app_dir, &gradle_env)
-            .map_err(GradleBuildpackError::GetDependencyReportError)
-            .map(|dependency_report| detect_framework(&dependency_report))?;
+        let detected_framework =
+            gradle_command::dependency_report(&context.app_dir, &gradle_env, &gradle_init_scripts)
+                .map_err(GradleBuildpackError::GetDependencyReportError)
+                .map(|dependency_report| detect_framework(&dependency_report))?;
 
         let task_name = buildpack_config
             .gradle_task
@@ -119,6 +128,7 @@ impl Buildpack for GradleBuildpack {
         let output = Command::new(&gradle_wrapper_executable_path)
             .current_dir(&context.app_dir)
             .envs(&gradle_env)
+            .args(gradle_init_script_args(&gradle_init_scripts))
             .args([task_name, "-x", "check"])
             .output_and_write_streams(stdout(), stderr())
             .map_err(GradleBuildIoError)?;

--- a/buildpacks/gradle/tests/integration/init_scripts.rs
+++ b/buildpacks/gradle/tests/integration/init_scripts.rs
@@ -1,0 +1,78 @@
+use crate::default_buildpacks;
+use buildpacks_jvm_shared_test::DEFAULT_INTEGRATION_TEST_BUILDER;
+use indoc::indoc;
+use libcnb_test::{assert_contains, BuildConfig, TestRunner};
+use std::fs;
+
+#[test]
+#[ignore = "integration test"]
+fn init() {
+    let build_config = BuildConfig::new(
+        DEFAULT_INTEGRATION_TEST_BUILDER,
+        "test-apps/heroku-gradle-getting-started",
+    )
+    .buildpacks(default_buildpacks())
+    .app_dir_preprocessor(|dir| {
+        let init_script_dir = dir.join(".heroku/gradle/init.d");
+        fs::create_dir_all(&init_script_dir).unwrap();
+
+        fs::write(
+            init_script_dir.join("kotlin_custom_init.init.gradle.kts"),
+            GRADLE_INIT_SCRIPT_KOTLIN,
+        )
+        .unwrap();
+
+        fs::write(
+            init_script_dir.join("groovy_custom_init.gradle"),
+            GRADLE_INIT_SCRIPT_GROOVY,
+        )
+        .unwrap();
+    })
+    .to_owned();
+
+    TestRunner::default().build(&build_config, |context| {
+        assert_contains!(context.pack_stdout, "Kotlin init-script running...");
+        assert_contains!(context.pack_stdout, "Groovy init-script running...");
+
+        assert_contains!(
+            context.pack_stdout,
+            "Kotlin output from Apache Commons Mathematics: 1"
+        );
+        assert_contains!(
+            context.pack_stdout,
+            "Groovy output from Apache Commons Mathematics: 1"
+        );
+    });
+}
+
+const GRADLE_INIT_SCRIPT_KOTLIN: &str = indoc! {r#"
+    import org.apache.commons.math.fraction.Fraction
+
+    initscript {
+        repositories {
+            mavenCentral()
+        }
+        dependencies {
+            classpath("org.apache.commons:commons-math:2.0")
+        }
+    }
+
+    println("Kotlin init-script running...")
+    println("Kotlin output from Apache Commons Mathematics: " + Fraction.ONE_FIFTH.multiply(5))
+"#};
+
+const GRADLE_INIT_SCRIPT_GROOVY: &str = indoc! {"
+    import org.apache.commons.math.fraction.Fraction
+
+    initscript {
+        repositories {
+            mavenCentral()
+        }
+        dependencies {
+            classpath 'org.apache.commons:commons-math:2.0'
+        }
+    }
+
+    println 'Groovy init-script running...'
+    println 'Groovy output from Apache Commons Mathematics: ' + Fraction.ONE_FIFTH.multiply(5)
+"};

--- a/buildpacks/gradle/tests/integration/main.rs
+++ b/buildpacks/gradle/tests/integration/main.rs
@@ -10,6 +10,7 @@
 
 use libcnb_test::BuildpackReference;
 
+mod init_scripts;
 mod smoke;
 mod ux;
 


### PR DESCRIPTION
Adds support for [Gradle init scripts](https://docs.gradle.org/8.5/userguide/init_scripts.html). Kotlin and/or Groovy init scripts in `$APP_DIR/.heroku/gradle/init.d` will be automatically picked up by the buildpack and passed to Gradle.

Since this buildpack manages `GRADLE_USER_HOME` and the Gradle CLI invocations, users would have no way to add an init script by other means. Most users will be able to add the contents of their init scripts to their build and don't even need to use this feature. But some enterprise customers will have a set of shared init scripts that are centrally managed (i.e. via Git submodules).

GUS-W-14608479