### PR TITLE
Reduce JVM flags to `-XX:MaxRAMPercentage=80.0` for non Eco, Basic and Standard-*X dynos

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* For containers that do not correspond to `Eco`, `Basic`, `Standard-1X`, `Standard-2X` or `Private-S` Heroku dyno types, only `-XX:MaxRAMPercentage=80.0` will now be passed to the JVM via `JAVA_TOOL_OPTIONS`. ([#631](https://github.com/heroku/buildpacks-jvm/pull/631))
 * Default version for **OpenJDK 8** is now `1.8.0_402`. ([#630](https://github.com/heroku/buildpacks-jvm/pull/630))
 * Default version for **OpenJDK 11** is now `11.0.22`. ([#630](https://github.com/heroku/buildpacks-jvm/pull/630))
 * Default version for **OpenJDK 17** is now `17.0.10`.([#630](https://github.com/heroku/buildpacks-jvm/pull/630))

--- a/buildpacks/jvm/src/bin/heroku_dynamic_jvm_opts.rs
+++ b/buildpacks/jvm/src/bin/heroku_dynamic_jvm_opts.rs
@@ -27,15 +27,13 @@ fn output_from_env(env: &Env) -> HashMap<ExecDProgramOutputKey, String> {
 
 fn dyno_type_jvm_opts() -> Vec<&'static str> {
     match detect_available_memory() {
-        // Free, Hobby, Standard-1X
+        // Eco, Basic, Standard-1X
         Some(536_870_912) => vec!["-Xmx300m", "-Xss512k", "-XX:CICompilerCount=2"],
         // Standard-2X, Private-S
         Some(1_073_741_824) => vec!["-Xmx671m", "-XX:CICompilerCount=2"],
-        // Performance-M, Private-M
-        Some(2_684_354_560) => vec!["-Xmx2g"],
-        // Performance-L, Private-L
-        Some(15_032_385_536) => vec!["-Xmx12g"],
-        _ => vec![],
+        // Rely on JVM ergonomics for other dyno types, but increase the maximum RAM percentage from 25% to 80%.
+        // This is to ensure max heap configuration is aligned to the existing Heroku JVM buildpacks.
+        _ => vec!["-XX:MaxRAMPercentage=80.0"],
     }
 }
 
@@ -44,7 +42,7 @@ fn detect_available_memory() -> Option<usize> {
         "/sys/fs/cgroup/memory.max",
         "/sys/fs/cgroup/memory/memory.limit_in_bytes",
     ]
-    .iter()
+    .into_iter()
     .find_map(|path| std::fs::read_to_string(path).ok())
     .and_then(|contents| contents.trim().parse().ok())
 }


### PR DESCRIPTION
In addition to porting the changes from the existing Heroku JVM buildpack, the defaults for `Performance-M` and `Performance-L` are also removed. Their previous defaults have either the same effect as `XX:MaxRAMPercentage=80.0` or are _very_ close to it. We didn't change this for the existing buildpacks, but for CNBs this is a low-risk change that streamlines the defaults we use.

Ref: GUS-W-14846033