### PR TITLE
Reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
+# Default to requesting pull request reviews from the Heroku Languages team.
 * @heroku/languages
 
-# Reduce team review request noise for Dependabot updates and automated release PRs.
+# However, request review from the language owner instead for files that are updated
+# by Dependabot or release automation, to reduce team review request noise.
 buildpack.toml @Malax
 CHANGELOG.md @Malax
 Cargo.toml @Malax

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
 * @heroku/languages
+
+# Reduce team review request noise for Dependabot updates and automated release PRs.
+buildpack.toml @Malax
+CHANGELOG.md @Malax
+Cargo.toml @Malax
+Cargo.lock @Malax
+pom.xml @Malax


### PR DESCRIPTION
The `CODEOWNERS` file has been adjusted to request review from the primary repository maintainer for high-traffic files that are typically updated via automation, rather than requesting review from the whole team.

This:
- reduces team notification/review request noise for Dependabot and release automation PRs, given that other members on the team usually aren't going to look at such PRs anyway, and it only makes it harder for team members to see the review requests that are actually in their queue
- retains the "team awareness" benefit of having the team see notifications for all other non-automated PRs
- retains the UX benefit of having a reviewer be automatically selected

In the scenarios where either the primary repository maintainer is away, or they are the person opening the PR (so can't request review from themselves), other team members will still be able to approve the PR with the changes I've made to the branch protection settings (unchecking "Require Code Owner Review", leaving "require approvals" enabled which can only be from teams with write access, which is only us. Plus for bonus points, the option to only permit merging from members of our team has also been enabled).

For supported syntax, see:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

GUS-W-14941625.