### PR TITLE
Use the Procfile CNB from the builder in tests

### DIFF
--- a/buildpacks/gradle/tests/integration/main.rs
+++ b/buildpacks/gradle/tests/integration/main.rs
@@ -17,8 +17,6 @@ fn default_buildpacks() -> Vec<BuildpackReference> {
     vec![
         BuildpackReference::Other(String::from("heroku/jvm")),
         BuildpackReference::CurrentCrate,
-        // Using an explicit version from Docker Hub to prevent failures when there
-        // are multiple Procfile buildpack versions in the builder image.
-        BuildpackReference::Other(String::from("docker://docker.io/heroku/procfile-cnb:2.0.1")),
+        BuildpackReference::Other(String::from("heroku/procfile")),
     ]
 }

--- a/buildpacks/sbt/tests/integration/main.rs
+++ b/buildpacks/sbt/tests/integration/main.rs
@@ -19,8 +19,6 @@ fn default_buildpacks() -> Vec<BuildpackReference> {
     vec![
         BuildpackReference::Other(String::from("heroku/jvm")),
         BuildpackReference::CurrentCrate,
-        // Using an explicit version from Docker Hub to prevent failures when there
-        // are multiple Procfile buildpack versions in the builder image.
-        BuildpackReference::Other(String::from("docker://docker.io/heroku/procfile-cnb:2.0.1")),
+        BuildpackReference::Other(String::from("heroku/procfile")),
     ]
 }


### PR DESCRIPTION
The Procfile CNB has just moved Docker Hub repo:
https://github.com/heroku/buildpacks-procfile/pull/219

Instead of updating the repo URL used in the tests, I've switched the tests to use the Procfile CNB from the builder image instead.

This is now safe to do, since there is now only ever one Procfile version in the builder after:
https://github.com/heroku/buildpacks-jvm/pull/608
https://github.com/heroku/buildpacks-nodejs/pull/696

Using the Procfile version from the builder has a few advantages:
- Greater parity with what will be used in production
- Less churn from us needing to bump the versions here
- Faster, since saves having to pull a new image from Docker Hub

There is the chance of breakage, should the upstream Procfile CNB make a breaking change, however, that should be very rare and will only affect tests, and seeing that breakage here is actually kinda the point :-)

GUS-W-14356096.