### PR TITLE
Remove unused `ParseError`

### DIFF
--- a/buildpacks/gradle/src/gradle_command/dependency_report.rs
+++ b/buildpacks/gradle/src/gradle_command/dependency_report.rs
@@ -101,9 +101,6 @@ pub(crate) enum Suffix {
     NotResolved,
 }
 
-#[derive(Debug)]
-enum ParseError {}
-
 mod parser {
     use super::{Dependency, GradleDependencyReport, Suffix};
     use nom::branch::alt;


### PR DESCRIPTION
Removing it now since it causes linting errors with `clippy 0.1.78 (9b00956e 2024-04-29)`.