### PR TITLE
libcnb `0.21` and CNB targets support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -290,12 +290,13 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set",
- "regex",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -313,7 +314,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -414,7 +415,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -490,9 +491,9 @@ checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libcnb"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c385c618fa8afebe2d1b499b74bc0a3682507b0d91aa4aad09708b81681e2ca"
+checksum = "aacc89bfeaef5f43cdee664798e3c0aa36e052a412ab1391f0750aee4df1f407"
 dependencies = [
  "libcnb-common",
  "libcnb-data",
@@ -504,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-common"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fede7cd4353004ff1976ce66c34bb266fa35095be12c6d3d4c2358ef790778"
+checksum = "a356bd77381b51f1ca42450694f4c7d1c7533a57c5f6a49553a96af96963b6e3"
 dependencies = [
  "serde",
  "thiserror",
@@ -515,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-data"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c0c825002ee57279d0c9e23309863804536f0c45687436d574dd3e8c7420fb"
+checksum = "dfcd102bfb1bf98ee4c18da0b29be6f23a19681937924bf758e9ea8499668b18"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -529,12 +530,13 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934ec4398991f7e926889a6e5046d83935e39de5c047feb591ed0333b83abf75"
+checksum = "3b8d9b42112212a875c07fb3acf19504cf330edaa63cddd1823e9d03a5e2b934"
 dependencies = [
  "cargo_metadata",
  "ignore",
+ "indoc",
  "libcnb-common",
  "libcnb-data",
  "petgraph",
@@ -545,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f0afde3a7327936afd743e2cb52f6de3a0d4a4894f6f13bdae1a41e6879c17"
+checksum = "f83bba477c3a6cd69b29f77a6591411bac15ab7b341ad3d3cd38943bfbbd412f"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
@@ -557,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-test"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2471f098af746db385e0e254dd423de21db3347ea26cfd4c758a37cccaa1674a"
+checksum = "9471152703833b74d565c7f7c910b4d5e084f955c327eba2bdb6658e86bd6dd6"
 dependencies = [
  "fastrand",
  "fs_extra",
@@ -572,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e800ca80376b707d57d55ea95f48c88d2621864a0250cc41f54eab8e9481887"
+checksum = "146f61983fd384cb5ab5373acdd8f53fcb4b27ecb200435a6bfb6a70b421bc9d"
 dependencies = [
  "crossbeam-utils",
  "flate2",
@@ -773,7 +775,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -786,7 +788,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -961,7 +963,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1151,15 +1153,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "5.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
- "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "winsafe",
 ]
 
 [[package]]
@@ -1168,16 +1169,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1186,22 +1178,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1210,21 +1187,15 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1234,21 +1205,9 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1264,21 +1223,9 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1288,21 +1235,9 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1318,6 +1253,12 @@ checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "zeroize"

--- a/buildpacks/gradle/CHANGELOG.md
+++ b/buildpacks/gradle/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
 ## [4.1.1] - 2024-05-01
 
 - No changes.

--- a/buildpacks/gradle/CHANGELOG.md
+++ b/buildpacks/gradle/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Buildpack API version changed from `0.9` to `0.10`, and so requires `lifecycle` `0.17.x` or newer. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 
 ## [4.1.1] - 2024-05-01
 

--- a/buildpacks/gradle/Cargo.toml
+++ b/buildpacks/gradle/Cargo.toml
@@ -9,11 +9,11 @@ workspace = true
 [dependencies]
 buildpacks-jvm-shared.workspace = true
 indoc = "2"
-libcnb = "=0.17.0"
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["command", "error", "log"] }
+libcnb = "=0.21.0"
+libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["command", "error", "log"] }
 nom = "7"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 buildpacks-jvm-shared-test.workspace = true
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.21.0"

--- a/buildpacks/gradle/buildpack.toml
+++ b/buildpacks/gradle/buildpack.toml
@@ -12,6 +12,11 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
+# This workaround can be removed once a new Pack release ships that includes:
+# https://github.com/buildpacks/pack/pull/2081
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/gradle/buildpack.toml
+++ b/buildpacks/gradle/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/gradle"

--- a/buildpacks/gradle/buildpack.toml
+++ b/buildpacks/gradle/buildpack.toml
@@ -12,8 +12,9 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-[[stacks]]
-id = "*"
+[[targets]]
+os = "linux"
+arch = "amd64"
 
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-gradle" }

--- a/buildpacks/gradle/src/layers/gradle_home.rs
+++ b/buildpacks/gradle/src/layers/gradle_home.rs
@@ -24,7 +24,7 @@ impl Layer for GradleHomeLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
@@ -63,7 +63,7 @@ impl Layer for GradleHomeLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         _layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
@@ -71,7 +71,7 @@ impl Layer for GradleHomeLayer {
     }
 
     fn update(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Buildpack API version changed from `0.9` to `0.10`, and so requires `lifecycle` `0.17.x` or newer. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 
 ## [4.1.1] - 2024-05-01
 

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
 ## [4.1.1] - 2024-05-01
 
 - No changes.
@@ -159,6 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.8] - 2021-05-17
 
 ### Changed
+
 * `SF_FX_REMOTE_DEBUG` was renamed to `DEBUG_PORT` and also species the port on with the JDWP agent will listen on.
 * Updated function runtime to `0.2.1`
 * Update `bin/detect` to check for `type=function`.
@@ -166,28 +171,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.7] - 2021-05-05
 
 ### Changed
+
 * Updated function runtime to `0.2.0`
 
 ### Added
+
 * Support for the `SF_FX_REMOTE_DEBUG` runtime environment variable. If set, the invoker will listen for incoming JDWP
   connections on port `5005`.
 
 ### Changed
+
 * Detection now checks for `project.toml` in addition to `function.toml` to determine if an app is a function.
 
 ## [0.2.6] - 2021-04-29
 
 ### Changed
+
 * Updated function runtime to `0.1.4-ea`
 
 ## [0.2.5] - 2021-04-21
 
 ### Changed
+
 * Updated function runtime to `0.1.3-ea`
 
 ## [0.2.4] - 2021-04-08
 
 ### Fixed
+
 * Fixed `licenses` in `buildpack.toml`
 * Updated function runtime to `0.1.1-ea`
 
@@ -196,39 +207,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.2] - 2021-02-04
 
 ### Added
+
 * Support for the `PORT` environment variable at runtime for setting the HTTP port
 
 ### Fixed
+
 * When using an older version of `pack`, the function layer might be incorrectly restored, causing errors
   "directory not empty" during function detection. A workaround has been added.
 
 ## [0.2.1] - 2021-02-03
 
 ### Changed
+
 * Now requires (in the CNB sense) `jvm-application` to pass detection.
 * Will now fail detection if there is no `function.toml` present.
 
 ### Removed
+
 * The Java function runtime binary integrity is now checked after download (temporarily removed).
 * Java function runtime is now cached between builds (temporarily removed).
 
 ## [0.2.0] - 2021-02-01
 
 ### Changed
+
 * Function runtime binary URL no longer has to be specified with the `JVM_INVOKER_JAR_URL` environment variable.
 * Functions are now detected during build. This means the build will now fail if more or less than one valid
   Salesforce Java function is detected in the project.
 
 ### Added
+
 * The Java function runtime binary integrity is now checked after download.
 * Java function runtime is now cached between builds.
 
 ## [0.1.0] - 2021-01-21
 
 ### Added
+
 * Initial release.
 
-[unreleased]: https://github.com/heroku/buildpacks-jvm/compare/v4.1.1...HEAD
+[unreleased]: https://github.com/heroku/buildpacks-jvm/compare/v4.1.1...HEADs
 [4.1.1]: https://github.com/heroku/buildpacks-jvm/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/heroku/buildpacks-jvm/compare/v4.0.2...v4.1.0
 [4.0.2]: https://github.com/heroku/buildpacks-jvm/compare/v4.0.1...v4.0.2

--- a/buildpacks/jvm-function-invoker/CHANGELOG.md
+++ b/buildpacks/jvm-function-invoker/CHANGELOG.md
@@ -246,7 +246,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Initial release.
 
-[unreleased]: https://github.com/heroku/buildpacks-jvm/compare/v4.1.1...HEADs
+[unreleased]: https://github.com/heroku/buildpacks-jvm/compare/v4.1.1...HEAD
 [4.1.1]: https://github.com/heroku/buildpacks-jvm/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/heroku/buildpacks-jvm/compare/v4.0.2...v4.1.0
 [4.0.2]: https://github.com/heroku/buildpacks-jvm/compare/v4.0.1...v4.0.2

--- a/buildpacks/jvm-function-invoker/Cargo.toml
+++ b/buildpacks/jvm-function-invoker/Cargo.toml
@@ -8,8 +8,8 @@ workspace = true
 
 [dependencies]
 indoc = "2"
-libcnb = "=0.17.0"
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["digest", "download", "error", "log", "toml"] }
+libcnb = "=0.21.0"
+libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["digest", "download", "error", "log", "toml"] }
 serde = "1"
 thiserror = "1"
 toml = "0.8"
@@ -17,6 +17,6 @@ toml = "0.8"
 [dev-dependencies]
 base64 = "0.22"
 buildpacks-jvm-shared-test.workspace = true
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.21.0"
 tempfile = "3"
 ureq = { version = "2", default-features = false, features = ["tls"] }

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/jvm-function-invoker"

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -11,8 +11,9 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-[[stacks]]
-id = "*"
+[[targets]]
+os = "linux"
+arch = "amd64"
 
 [metadata.runtime]
 url = "https://repo1.maven.org/maven2/com/salesforce/functions/sf-fx-runtime-java-runtime/1.1.6/sf-fx-runtime-java-runtime-1.1.6-jar-with-dependencies.jar"

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -11,6 +11,11 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
+# This workaround can be removed once a new Pack release ships that includes:
+# https://github.com/buildpacks/pack/pull/2081
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/jvm-function-invoker/src/layers/bundle.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/bundle.rs
@@ -29,7 +29,7 @@ impl Layer for BundleLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, JvmFunctionInvokerBuildpackError> {

--- a/buildpacks/jvm-function-invoker/src/layers/opt.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/opt.rs
@@ -25,7 +25,7 @@ impl Layer for OptLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, JvmFunctionInvokerBuildpackError> {

--- a/buildpacks/jvm-function-invoker/src/layers/runtime.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/runtime.rs
@@ -31,7 +31,7 @@ impl Layer for RuntimeLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, JvmFunctionInvokerBuildpackError> {
@@ -67,7 +67,7 @@ impl Layer for RuntimeLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, JvmFunctionInvokerBuildpackError> {

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- This buildpack is no longer Heroku stack specific and can be used with most x86 Linux based CNB build and run images. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Default OpenJDK distribution is now always Azul® Zulu®. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
+### Removed
+
+- Support for Heroku's own OpenJDK build distribution. Users that explicitly request that distribution by prefixing their OpenJDK version with `heroku-` need to either remove the prefix or replace it with `zulu-`. Azul Zulu is a drop-in replacement for the Heroku OpenJDK distribution. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
 ## [4.1.1] - 2024-05-01
 
 ### Changed
@@ -188,6 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.15] - 2022-03-24
 
 ### Added
+
 * Support for Java 18
 
 ## [0.1.14] - 2022-03-02
@@ -213,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.11] - 2021-10-28
 
 ### Changed
+
 * Default version for **OpenJDK 7** is now `1.7.0_322`
 * Default version for **OpenJDK 17** is now `17.0.1`
 
@@ -221,6 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.9] - 2021-10-19
 
 ### Changed
+
 * Default version for **OpenJDK 8** is now `1.8.0_312`
 * Default version for **OpenJDK 11** is now `11.0.13`
 * Default version for **OpenJDK 13** is now `13.0.9`
@@ -229,14 +242,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.8] - 2021-09-15
 
 ### Added
+
 * Support for Java 17
 
 ### Fixed
+
 * Updated GPG public key
 
 ## [0.1.7] - 2021-07-28
 
 ### Changed
+
 * Default version for **OpenJDK 7** is now `1.7.0_312`
 * Default version for **OpenJDK 8** is now `1.8.0_302`
 * Default version for **OpenJDK 11** is now `11.0.12`
@@ -247,6 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.6] - 2021-04-29
 
 ### Changed
+
 * Default version for **OpenJDK 7** is now `1.7.0_302`
 * Default version for **OpenJDK 8** is now `1.8.0_292`
 * Default version for **OpenJDK 11** is now `11.0.11`
@@ -255,11 +272,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Default version for **OpenJDK 16** is now `16.0.1`
 
 ### Fixed
+
 * Fixed `licenses` in `buildpack.toml`
 
 ## [0.1.5] - 2021-03-17
 
 ### Added
+
 * Support for Java 16
 
 ## [0.1.4] - 2021-02-23
@@ -267,14 +286,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.3] - 2021-02-04
 
 ### Changed
+
 * Status headers are now bold
 
 ### Fixed
+
 * `JAVA_HOME` will now be correctly set when using older versions of `pack`
 
 ## [0.1.2] - 2021-01-22
 
 ### Changed
+
 * Default version for **OpenJDK 7** is now `1.7.0_292`
 * Default version for **OpenJDK 8** is now `1.8.0_282`
 * Default version for **OpenJDK 11** is now `11.0.10`
@@ -284,6 +306,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2021-01-19
 
 ### Added
+
 * Automated post-release PRs
 
 ## [0.1.0] - 2021-01-14

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Buildpack API version changed from `0.9` to `0.10`, and so requires `lifecycle` `0.17.x` or newer. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 - This buildpack is no longer Heroku stack specific and can be used with most x86 Linux based CNB build and run images. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 - Default OpenJDK distribution is now always Azul® Zulu®. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -10,8 +10,8 @@ workspace = true
 buildpacks-jvm-shared.workspace = true
 fs_extra = "1"
 indoc = "2"
-libcnb = "=0.17.0"
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["digest", "download", "error", "log", "tar"] }
+libcnb = "=0.21.0"
+libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["digest", "download", "error", "log", "tar"] }
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"
 ureq = { version = "2", default-features = false, features = ["tls"] }
@@ -19,4 +19,4 @@ url = "2"
 
 [dev-dependencies]
 buildpacks-jvm-shared-test.workspace = true
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.21.0"

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -11,6 +11,11 @@ keywords = ["openjdk", "heroku"]
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
+# This workaround can be removed once a new Pack release ships that includes:
+# https://github.com/buildpacks/pack/pull/2081
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/jvm"

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -11,11 +11,9 @@ keywords = ["openjdk", "heroku"]
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-[[stacks]]
-id = "heroku-20"
-
-[[stacks]]
-id = "heroku-22"
+[[targets]]
+os = "linux"
+arch = "amd64"
 
 [metadata.heroku-metrics-agent]
 url = "https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/4.0.1/heroku-java-metrics-agent-4.0.1.jar"

--- a/buildpacks/jvm/src/layers/heroku_metrics_agent.rs
+++ b/buildpacks/jvm/src/layers/heroku_metrics_agent.rs
@@ -29,7 +29,7 @@ impl Layer for HerokuMetricsAgentLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
@@ -60,7 +60,7 @@ impl Layer for HerokuMetricsAgentLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/jvm/src/layers/openjdk.rs
+++ b/buildpacks/jvm/src/layers/openjdk.rs
@@ -37,7 +37,7 @@ impl Layer for OpenJdkLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, OpenJdkBuildpackError> {
@@ -139,7 +139,7 @@ impl Layer for OpenJdkLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, OpenJdkBuildpackError> {

--- a/buildpacks/jvm/src/layers/runtime.rs
+++ b/buildpacks/jvm/src/layers/runtime.rs
@@ -21,7 +21,7 @@ impl Layer for RuntimeLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         _layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -85,7 +85,6 @@ impl Buildpack for OpenJdkBuildpack {
             .map_err(OpenJdkBuildpackError::ReadVersionStringError)?;
 
         let normalized_version = version::normalize_version_string(
-            &context.stack_id,
             app_dir_version_string.unwrap_or_else(|| String::from("8")),
         )
         .map_err(OpenJdkBuildpackError::NormalizeVersionStringError)?;
@@ -94,7 +93,6 @@ impl Buildpack for OpenJdkBuildpack {
             layer_name!("openjdk"),
             OpenJdkLayer {
                 tarball_url: version::resolve_openjdk_url(
-                    &context.stack_id,
                     normalized_version.0,
                     normalized_version.1,
                 ),

--- a/buildpacks/jvm/src/version.rs
+++ b/buildpacks/jvm/src/version.rs
@@ -34,21 +34,13 @@ pub(crate) fn normalize_version_string<S: Into<String>>(
     };
 
     match user_distribution_string {
-        None => Ok(default_distribution(stack_id)),
-        Some("heroku" | "openjdk") => Ok(OpenJDKDistribution::Heroku),
+        None => Ok(OpenJDKDistribution::default()),
         Some("zulu") => Ok(OpenJDKDistribution::AzulZulu),
         Some(unknown) => Err(NormalizeVersionStringError::UnknownDistribution(
             String::from(unknown),
         )),
     }
     .map(|distribution| (distribution, String::from(version_string)))
-}
-
-fn default_distribution(stack_id: &StackId) -> OpenJDKDistribution {
-    match stack_id.as_str() {
-        "heroku-18" | "heroku-20" => OpenJDKDistribution::Heroku,
-        _ => OpenJDKDistribution::AzulZulu,
-    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -65,16 +57,15 @@ pub(crate) fn resolve_openjdk_url<V: Into<String>>(
     let base_url = format!("https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/{stack_id}");
 
     let file_name = match distribution {
-        OpenJDKDistribution::Heroku => format!("openjdk{version_string}.tar.gz"),
         OpenJDKDistribution::AzulZulu => format!("zulu-{version_string}.tar.gz"),
     };
 
     format!("{base_url}/{file_name}")
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub(crate) enum OpenJDKDistribution {
-    Heroku,
+    #[default]
     AzulZulu,
 }
 

--- a/buildpacks/jvm/src/version.rs
+++ b/buildpacks/jvm/src/version.rs
@@ -1,7 +1,4 @@
-use libcnb::data::buildpack::StackId;
-
 pub(crate) fn normalize_version_string<S: Into<String>>(
-    stack_id: &StackId,
     user_version_string: S,
 ) -> Result<(OpenJDKDistribution, String), NormalizeVersionStringError> {
     let user_version_string = user_version_string.into();
@@ -49,18 +46,17 @@ pub(crate) enum NormalizeVersionStringError {
 }
 
 pub(crate) fn resolve_openjdk_url<V: Into<String>>(
-    stack_id: &StackId,
     distribution: OpenJDKDistribution,
     version_string: V,
 ) -> String {
     let version_string = version_string.into();
-    let base_url = format!("https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/{stack_id}");
 
-    let file_name = match distribution {
-        OpenJDKDistribution::AzulZulu => format!("zulu-{version_string}.tar.gz"),
-    };
-
-    format!("{base_url}/{file_name}")
+    match distribution {
+        // We're using the legacy stack specific URL of heroku-22 for all targets. This is not a
+        // problem as the distribution hosted there is NOT stack specific. This will eventually be
+        // replaced with a stack agnostic URL.
+        OpenJDKDistribution::AzulZulu => format!("https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-22/zulu-{version_string}.tar.gz"),
+    }
 }
 
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
@@ -72,106 +68,52 @@ pub(crate) enum OpenJDKDistribution {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libcnb::data::stack_id;
 
     #[test]
-    fn normalize_version_string_stack_specific_distribution() {
-        assert_eq!(
-            normalize_version_string(&stack_id!("heroku-18"), "8"),
-            Ok((OpenJDKDistribution::Heroku, String::from("1.8.0_412")))
-        );
+    fn test_normalize_version_string() {
+        let zulu = OpenJDKDistribution::AzulZulu;
 
-        assert_eq!(
-            normalize_version_string(&stack_id!("heroku-20"), "8"),
-            Ok((OpenJDKDistribution::Heroku, String::from("1.8.0_412")))
-        );
+        let latest_java_8 = "1.8.0_412";
+        let latest_java_11 = "11.0.23";
+        let latest_java_21 = "21.0.3";
 
-        assert_eq!(
-            normalize_version_string(&stack_id!("heroku-22"), "8"),
-            Ok((OpenJDKDistribution::AzulZulu, String::from("1.8.0_412")))
-        );
-
-        assert_eq!(
-            normalize_version_string(&stack_id!("bogus"), "8"),
-            Ok((OpenJDKDistribution::AzulZulu, String::from("1.8.0_412")))
-        );
-    }
-
-    #[test]
-    fn foo() {
-        assert_eq!(
-            resolve_openjdk_url(
-                &stack_id!("heroku-20"),
-                OpenJDKDistribution::Heroku,
-                "1.0.0"
+        let test_cases = [
+            // OpenJDK 8
+            ("8", Ok((zulu, String::from(latest_java_8)))),
+            (latest_java_8, Ok((zulu, String::from(latest_java_8)))),
+            ("zulu-8", Ok((zulu, String::from(latest_java_8)))),
+            (
+                &format!("zulu-{latest_java_8}"),
+                Ok((zulu, String::from(latest_java_8))),
             ),
-            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-20/openjdk1.0.0.tar.gz"
-        );
-
-        assert_eq!(
-            resolve_openjdk_url(
-                &stack_id!("heroku-20"),
-                OpenJDKDistribution::Heroku,
-                "1.2.3"
+            // OpenJDK 11
+            ("11", Ok((zulu, String::from(latest_java_11)))),
+            (latest_java_11, Ok((zulu, String::from(latest_java_11)))),
+            ("zulu-11", Ok((zulu, String::from(latest_java_11)))),
+            (
+                &format!("zulu-{latest_java_11}"),
+                Ok((zulu, String::from(latest_java_11))),
             ),
-            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-20/openjdk1.2.3.tar.gz"
-        );
-
-        assert_eq!(
-            resolve_openjdk_url(
-                &stack_id!("heroku-22"),
-                OpenJDKDistribution::Heroku,
-                "1.2.3"
+            // OpenJDK 21
+            ("21", Ok((zulu, String::from(latest_java_21)))),
+            ("zulu-21", Ok((zulu, String::from(latest_java_21)))),
+            // Other
+            ("1337", Ok((zulu, String::from("1337")))),
+            (
+                "4.8.15.16.23.42",
+                Ok((zulu, String::from("4.8.15.16.23.42"))),
             ),
-            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-22/openjdk1.2.3.tar.gz"
-        );
-
-        assert_eq!(
-            resolve_openjdk_url(
-                &stack_id!("heroku-18"),
-                OpenJDKDistribution::Heroku,
-                "1.2.3.4.5-suffix"
+            // Errors
+            (
+                "heroku-21",
+                Err(NormalizeVersionStringError::UnknownDistribution(
+                    String::from("heroku"),
+                )),
             ),
-            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-18/openjdk1.2.3.4.5-suffix.tar.gz"
-        );
-    }
+        ];
 
-    #[test]
-    fn foo_zulu() {
-        assert_eq!(
-            resolve_openjdk_url(
-                &stack_id!("heroku-20"),
-                OpenJDKDistribution::AzulZulu,
-                "1.0.0"
-            ),
-            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-20/zulu-1.0.0.tar.gz"
-        );
-
-        assert_eq!(
-            resolve_openjdk_url(
-                &stack_id!("heroku-20"),
-                OpenJDKDistribution::AzulZulu,
-                "1.2.3"
-            ),
-            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-20/zulu-1.2.3.tar.gz"
-        );
-
-        assert_eq!(
-            resolve_openjdk_url(
-                &stack_id!("heroku-22"),
-                OpenJDKDistribution::AzulZulu,
-                "1.2.3"
-            ),
-            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-22/zulu-1.2.3.tar.gz"
-        );
-
-        assert_eq!(
-            resolve_openjdk_url(
-                &stack_id!("heroku-18"),
-                OpenJDKDistribution::AzulZulu,
-                "1.2.3.4.5-suffix"
-            ),
-            "https://lang-jvm.s3.us-east-1.amazonaws.com/jdk/heroku-18/zulu-1.2.3.4.5-suffix.tar.gz"
-        );
+        for (input, expected_output) in test_cases {
+            assert_eq!(normalize_version_string(input), expected_output);
+        }
     }
 }

--- a/buildpacks/jvm/tests/integration/versions.rs
+++ b/buildpacks/jvm/tests/integration/versions.rs
@@ -8,7 +8,7 @@ fn test_openjdk_8_distribution_heroku_20() {
         |context| {
             assert_contains!(
                 context.run_shell_command("java -version").stderr,
-                "openjdk version \"1.8.0_412-heroku\""
+                "openjdk version \"1.8.0_412\""
             );
         },
     );

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
 ## [4.1.1] - 2024-05-01
 
 - No changes.
@@ -101,22 +105,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.5] - 2021-08-10
 
 ### Fixed
+
 * Ensures `mvnw` is executable
 
 ## [0.2.4] - 2021-07-16
 
 ### Added
+
 * Loosen stack requirements allowing any linux distro use this buildpack
 
 ## [0.2.3] - 2021-05-05
 
 ### Added
+
 * Documentation in `README.md`
 * `M2_HOME` environment variable is now set for subsequent buildpacks if Maven was installed.
 * `MAVEN_OPTS` environment variable will be set for subsequent buildpacks to allow the use of the local
   repository layer without explicit configuration.
 
 ### Fixed
+
 * Fixed `licenses` in `buildpack.toml`
 
 ## [0.2.2] - 2021-02-23
@@ -124,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2021-02-03
 
 ### Added
+
 * Automated post-release PRs
 * Now requires (in the CNB sense) `jdk` to pass detection
 * Now provides (in the CNB sense) `jvm-application` to subsequent buildpacks
@@ -131,9 +140,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2021-01-19
 
 ### Added
+
 * Debug logging, can be enabled by setting `HEROKU_BUILDPACK_DEBUG` environment variable
 
 ### Changed
+
 * Code refactoring
 * Logging style now adheres to Heroku's CNB logging style
 * Maven options that are implementation details are no longer logged by default
@@ -141,6 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MAVEN_CUSTOM_OPTS` or `MAVEN_CUSTOM_GOALS`
 
 ### Fixed
+
 * Caching of Maven dependencies
 * Exit code of `bin/detect` when detection failed without an error
 

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Buildpack API version changed from `0.9` to `0.10`, and so requires `lifecycle` `0.17.x` or newer. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 
 ## [4.1.1] - 2024-05-01
 

--- a/buildpacks/maven/Cargo.toml
+++ b/buildpacks/maven/Cargo.toml
@@ -10,8 +10,8 @@ workspace = true
 buildpacks-jvm-shared.workspace = true
 flate2 = { version = "1", default-features = false, features = ["zlib"] }
 indoc = "2"
-libcnb = "=0.17.0"
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["digest", "download", "error", "log"] }
+libcnb = "=0.21.0"
+libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["digest", "download", "error", "log"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 shell-words = "1"
@@ -21,4 +21,4 @@ tempfile = "3"
 [dev-dependencies]
 buildpacks-jvm-shared-test.workspace = true
 java-properties = "2"
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.21.0"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -12,6 +12,11 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
+# This workaround can be removed once a new Pack release ships that includes:
+# https://github.com/buildpacks/pack/pull/2081
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -12,8 +12,9 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-[[stacks]]
-id = "*"
+[[targets]]
+os = "linux"
+arch = "amd64"
 
 [metadata]
 default-version = "3.9.4"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/maven"

--- a/buildpacks/maven/src/layer/maven.rs
+++ b/buildpacks/maven/src/layer/maven.rs
@@ -31,7 +31,7 @@ impl Layer for MavenLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
@@ -80,7 +80,7 @@ impl Layer for MavenLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/maven/src/layer/maven_repo.rs
+++ b/buildpacks/maven/src/layer/maven_repo.rs
@@ -22,7 +22,7 @@ impl Layer for MavenRepositoryLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
@@ -46,7 +46,7 @@ impl Layer for MavenRepositoryLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         _layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/sbt/CHANGELOG.md
+++ b/buildpacks/sbt/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
 ## [4.1.1] - 2024-05-01
 
 - No changes.

--- a/buildpacks/sbt/CHANGELOG.md
+++ b/buildpacks/sbt/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Buildpack API version changed from `0.9` to `0.10`, and so requires `lifecycle` `0.17.x` or newer. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 
 ## [4.1.1] - 2024-05-01
 

--- a/buildpacks/sbt/Cargo.toml
+++ b/buildpacks/sbt/Cargo.toml
@@ -10,14 +10,14 @@ workspace = true
 buildpacks-jvm-shared.workspace = true
 indoc = "2"
 java-properties = "2"
-libcnb = "=0.17.0"
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["command", "error", "log"] }
+libcnb = "=0.21.0"
+libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["command", "error", "log"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 shell-words = "1"
 
 [dev-dependencies]
 buildpacks-jvm-shared-test.workspace = true
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.21.0"
 tempfile = "3"
 ureq = { version = "2", default-features = false, features = ["tls"] }

--- a/buildpacks/sbt/buildpack.toml
+++ b/buildpacks/sbt/buildpack.toml
@@ -12,6 +12,11 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
+# This workaround can be removed once a new Pack release ships that includes:
+# https://github.com/buildpacks/pack/pull/2081
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/sbt/buildpack.toml
+++ b/buildpacks/sbt/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/sbt"

--- a/buildpacks/sbt/buildpack.toml
+++ b/buildpacks/sbt/buildpack.toml
@@ -12,8 +12,9 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-[[stacks]]
-id = "*"
+[[targets]]
+os = "linux"
+arch = "amd64"
 
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-sbt" }

--- a/buildpacks/sbt/src/layers/dependency_resolver_home.rs
+++ b/buildpacks/sbt/src/layers/dependency_resolver_home.rs
@@ -30,7 +30,7 @@ impl Layer for DependencyResolverHomeLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
@@ -61,7 +61,7 @@ impl Layer for DependencyResolverHomeLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         _layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/sbt/src/layers/sbt_extras.rs
+++ b/buildpacks/sbt/src/layers/sbt_extras.rs
@@ -28,7 +28,7 @@ impl Layer for SbtExtrasLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
@@ -72,7 +72,7 @@ impl Layer for SbtExtrasLayer {
     }
 
     fn existing_layer_strategy(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         _layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {

--- a/buildpacks/sbt/src/layers/sbt_global.rs
+++ b/buildpacks/sbt/src/layers/sbt_global.rs
@@ -27,7 +27,7 @@ impl Layer for SbtGlobalLayer {
     }
 
     fn create(
-        &self,
+        &mut self,
         _context: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
 ## [4.1.1] - 2024-05-01
 
 ### Changed
@@ -279,7 +283,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.5] - 2021-04-08
 
 * Upgraded `heroku/jvm-function-invoker` to `0.2.4`
+
 ### Fixed
+
 * Fixed `licenses` in `buildpack.toml`
 
 ## [0.3.4] - 2021-03-17
@@ -304,7 +310,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2021-02-03
 
 * Upgraded `heroku/jvm-function-invoker` to `0.2.1`
+
 ### Changed
+
 * Now packages released buildpack images instead of local paths to ensure standalone and bundled
   versions are exactly the same.
 
@@ -315,12 +323,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2021-02-01
 
 ### Changed
+
 * Upgraded `heroku/jvm` to `0.1.3`
 * Upgraded `heroku/jvm-function-invoker` to `0.2.0`
 
 ## [0.1.0] - 2021-01-21
 
 ### Added
+
 * Initial release
 
 [unreleased]: https://github.com/heroku/buildpacks-jvm/compare/v4.1.1...HEAD

--- a/meta-buildpacks/java-function/CHANGELOG.md
+++ b/meta-buildpacks/java-function/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Buildpack API version changed from `0.9` to `0.10`, and so requires `lifecycle` `0.17.x` or newer. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 
 ## [4.1.1] - 2024-05-01
 

--- a/meta-buildpacks/java-function/buildpack.toml
+++ b/meta-buildpacks/java-function/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/java-function"

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
 ## [4.1.1] - 2024-05-01
 
 ### Changed
@@ -156,7 +160,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Upgraded `heroku/maven` to `1.0.1`
 * Upgraded `heroku/jvm` to `1.0.1`
+
 ### Breaking
+
 * Remove Gradle support from this meta-buildpack. Gradle support was realized by using a shimmed version of the `heroku/gradle` Heroku buildpack. We decided to strictly separate shimmed buildpacks from proper CNBs. Gradle support will be re-added later, using a native CNB. ([#308](https://github.com/heroku/buildpacks-jvm/pull/308))
 
 ## [0.5.0] - 2022-05-17
@@ -211,7 +217,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.6] - 2021-04-29
 
 * Upgraded `heroku/jvm` to `0.1.6`
+
 ### Fixed
+
 * Fixed `licenses` in `buildpack.toml`
 
 ## [0.3.5] - 2021-03-17
@@ -239,6 +247,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2021-02-03
 
 ### Changed
+
 * Now packages released buildpack images instead of local paths to ensure standalone and bundled
   versions are exactly the same.
 
@@ -247,11 +256,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Upgraded `heroku/jvm` to `0.1.3`
 
 ### Added
+
 * Automated post-release PRs
 
 ## [0.1.2] - 2012-01-19
 
 ### Changes
+
 * Upgrade `heroku/maven` to `0.2.0`
 
 ## [0.1.1] - 2012-01-13

--- a/meta-buildpacks/java/CHANGELOG.md
+++ b/meta-buildpacks/java/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Buildpack API version changed from `0.9` to `0.10`, and so requires `lifecycle` `0.17.x` or newer. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 
 ## [4.1.1] - 2024-05-01
 

--- a/meta-buildpacks/java/buildpack.toml
+++ b/meta-buildpacks/java/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/java"

--- a/meta-buildpacks/scala/CHANGELOG.md
+++ b/meta-buildpacks/scala/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+
 ## [4.1.1] - 2024-05-01
 
 ### Changed

--- a/meta-buildpacks/scala/CHANGELOG.md
+++ b/meta-buildpacks/scala/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Buildpack API version changed from `0.9` to `0.10`. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
+- Buildpack API version changed from `0.9` to `0.10`, and so requires `lifecycle` `0.17.x` or newer. ([#662](https://github.com/heroku/buildpacks-jvm/pull/662))
 
 ## [4.1.1] - 2024-05-01
 

--- a/meta-buildpacks/scala/buildpack.toml
+++ b/meta-buildpacks/scala/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
 id = "heroku/scala"

--- a/shared-test/Cargo.toml
+++ b/shared-test/Cargo.toml
@@ -8,5 +8,5 @@ workspace = true
 
 [dependencies]
 exponential-backoff = "1"
-libcnb-test = "=0.17.0"
+libcnb-test = "=0.21.0"
 ureq = { version = "2", default-features = false, features = ["tls"] }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,5 +9,5 @@ workspace = true
 [dependencies]
 indoc = "2"
 java-properties = "2"
-libcnb = "=0.17.0"
-libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["log"] }
+libcnb = "=0.21.0"
+libherokubuildpack = { version = "=0.21.0", default-features = false, features = ["log"] }


### PR DESCRIPTION
Main objective of this PR is to move to libcnb `0.21`. However, that includes other required changes that make most sense to do in the same PR.

With the removal of stacks, Heroku's own OpenJDK distribution cannot reliably supported anymore as it is stack specific. Therefore, this PR removes support for those OpenJDK builds. We are in the process of dropping support for our own builds independently of this PR and for our CNBs it makes sense to drop support now. Heroku's OpenJDK builds were only used as the default for the soon to be deprecated `heroku-20` stack - all other stacks used Azul's Zulu builds of OpenJDK as the default.

As both Heroku's and Azul's builds build from the same source, they can be used interchangeably. This has been proven when we changed the default distribution for heroku-22, where we had no reported issues by any customer.

GUS-W-15712484, Closes #659 