### PR TITLE
Remove Heroku support links on errors

### DIFF
--- a/buildpacks/gradle/CHANGELOG.md
+++ b/buildpacks/gradle/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Some error messages have changed so they longer suggest to open a Heroku support ticket. Instead, users are now provided with a link to create an issue on GitHub. ([#674](https://github.com/heroku/buildpacks-jvm/pull/674)) 
+
 ## [5.0.1] - 2024-05-23
 
 - No changes.

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Some error messages have changed so they longer suggest to open a Heroku support ticket. Instead, users are now provided with a link to create an issue on GitHub. ([#674](https://github.com/heroku/buildpacks-jvm/pull/674))
+
 ## [5.0.1] - 2024-05-23
 
 ### Changed

--- a/buildpacks/jvm/src/errors.rs
+++ b/buildpacks/jvm/src/errors.rs
@@ -1,6 +1,6 @@
 use crate::openjdk_artifact::HerokuOpenJdkVersionRequirement;
 use crate::{OpenJdkArtifactRequirementParseError, OpenJdkBuildpackError, ValidateSha256Error};
-use buildpacks_jvm_shared::log::log_please_try_again_error;
+use buildpacks_jvm_shared::log::{log_please_try_again, log_please_try_again_error};
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
 use libherokubuildpack::log::log_error;
@@ -29,27 +29,20 @@ pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
         OpenJdkBuildpackError::MetricsAgentSha256ValidationError(sha_256_error) => {
             match sha_256_error {
                 ValidateSha256Error::CouldNotObtainSha256(error) =>
-                    log_error(
+                    log_please_try_again_error(
                         "Heroku Metrics Agent download checksum error",
                         formatdoc! {"
                             Heroku Metrics Agent download succeeded, but an error occurred while verifying the
                             SHA256 checksum of the downloaded file.
-
-                            Please try again. If this error persists, please contact us:
-                            https://help.heroku.com/
-
-                            Details: {error}
-                        ", error = error },
+                        "},
+                        error
                     ),
                 ValidateSha256Error::InvalidChecksum { actual, expected } =>
-                    log_error(
+                    log_please_try_again(
                         "Heroku Metrics Agent download checksum error",
                         formatdoc! {"
                             Heroku Metrics Agent download succeeded, but the downloaded file's SHA256
                             checksum {actual} did not match the expected checksum {expected}.
-
-                            Please try again. If this error persists, please contact us:
-                            https://help.heroku.com/
                         ", actual = actual, expected = expected },
                     )
             }

--- a/buildpacks/maven/CHANGELOG.md
+++ b/buildpacks/maven/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Some error messages have changed so they longer suggest to open a Heroku support ticket. Instead, users are now provided with a link to create an issue on GitHub. ([#674](https://github.com/heroku/buildpacks-jvm/pull/674))
+
 ## [5.0.1] - 2024-05-23
 
 - No changes.

--- a/buildpacks/maven/tests/integration/misc.rs
+++ b/buildpacks/maven/tests/integration/misc.rs
@@ -123,12 +123,12 @@ fn descriptive_error_message_on_failed_build() {
 
             assert_contains!(
                 context.pack_stderr,
-                "[Error: Failed to build app with Maven]"
+                "[Error: Unexpected Maven exit code]"
             );
 
             assert_contains!(
                 context.pack_stderr,
-                "We're sorry this build is failing! If you can't find the issue in application code,\nplease submit a ticket so we can help: https://help.heroku.com/"
+                "Maven unexpectedly exited with code '1'. The most common reason for this are\nproblems with your application code and/or build configuration."
             );
         });
 }

--- a/buildpacks/sbt/CHANGELOG.md
+++ b/buildpacks/sbt/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Some error messages have changed so they longer suggest to open a Heroku support ticket. Instead, users are now provided with a link to create an issue on GitHub. ([#674](https://github.com/heroku/buildpacks-jvm/pull/674))
+
 ## [5.0.1] - 2024-05-23
 
 - No changes.

--- a/shared/src/log.rs
+++ b/shared/src/log.rs
@@ -1,6 +1,19 @@
 use indoc::formatdoc;
 use libherokubuildpack::log::log_error;
 use std::fmt::Debug;
+use std::process::ExitStatus;
+
+pub fn log_please_try_again<H: AsRef<str>, M: AsRef<str>>(header: H, message: M) {
+    log_error(
+        header,
+        formatdoc! {"
+            {message}
+
+            Please try again. If this error persists, please open an issue on GitHub:
+            https://github.com/heroku/buildpacks-jvm/issues/new
+        ", message = message.as_ref()},
+    );
+}
 
 pub fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
     header: H,
@@ -12,10 +25,36 @@ pub fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
         formatdoc! {"
             {message}
 
-            Please try again. If this error persists, please contact us:
-            https://help.heroku.com/
+            Please try again. If this error persists, please open an issue on GitHub:
+            https://github.com/heroku/buildpacks-jvm/issues/new
 
             Details: {error:?}
         ", message = message.as_ref(), error = error },
+    );
+}
+
+pub fn log_build_tool_unexpected_exit_code_error(build_tool_name: &str, exit_status: ExitStatus) {
+    let exit_code_string = exit_status
+        .code()
+        .map_or(String::from("<unknown>"), |code| code.to_string());
+
+    log_error(
+        format!("Unexpected {build_tool_name} exit code"),
+        formatdoc! { "
+            {build_tool_name} unexpectedly exited with code '{exit_code_string}'. The most common reason for this are
+            problems with your application code and/or build configuration.
+
+            Please refer to the {build_tool_name} output above for details. If you believe this error is not
+            caused by your application, please open an issue on GitHub:
+            https://github.com/heroku/buildpacks-jvm/issues/new
+        " },
+    );
+}
+
+pub fn log_build_tool_io_error(build_tool_name: &str, error: std::io::Error) {
+    log_please_try_again_error(
+        "Running {build_tool_name} failed",
+        format!("An unexpected IO error occurred while running {build_tool_name}."),
+        error,
     );
 }


### PR DESCRIPTION
Currently, some error messages suggest to open a Heroku support ticket. This behaviour was inherited from the existing Heroku buildpacks.

However, this doesn't make sense for our CNBs as they are not specific to the Heroku platform and can be used outside of it. Instead, users should open an issue on GitHub if they encounter a problem they need help with.

Otherwise, this PR does not change the error messages. I want to streamline errors between JVM buildpacks as well as adding stricter tests for them. But this is not the PR for that.