### PR TITLE
Enable dependabot for Git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,10 @@ updates:
       - "dependencies"
       - "github actions"
       - "skip changelog"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "skip changelog"


### PR DESCRIPTION
Getting started guide test fixtures as well as sbt-extras are added as a Git submodule in this repository.

Fixes #601.