### PR TITLE
Change default OpenJDK version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
+ "toml",
  "url",
 ]
 

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Checksum validation of downloaded OpenJDK distribution files. ([#680](https://github.com/heroku/buildpacks-jvm/pull/680))
-- A warning will now be shown when the OpenJDK version is not explicitly configured for an application. ([#781](https://github.com/heroku/buildpacks-jvm/pull/781))
+- A warning will now be shown when the OpenJDK version is not explicitly configured for an application. ([#681](https://github.com/heroku/buildpacks-jvm/pull/681))
 
 ### Changed
 
-- This buildpack now installs the latest long-term support release (currently 21) of OpenJDK if no version is explicitly configured. Previously, OpenJDK 8 was installed as the default. ([#781](https://github.com/heroku/buildpacks-jvm/pull/781))
+- This buildpack now installs the latest long-term support release (currently 21) of OpenJDK if no version is explicitly configured. Previously, OpenJDK 8 was installed as the default. ([#681](https://github.com/heroku/buildpacks-jvm/pull/681))
 - Some error messages have changed so they longer suggest to open a Heroku support ticket. Instead, users are now provided with a link to create an issue on GitHub. ([#674](https://github.com/heroku/buildpacks-jvm/pull/674))
 
 ### Removed

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Checksum validation of downloaded OpenJDK distribution files. ([#680](https://github.com/heroku/buildpacks-jvm/pull/680))
+- A warning will now be shown when the OpenJDK version is not explicitly configured for an application. ([#781](https://github.com/heroku/buildpacks-jvm/pull/781))
 
 ### Changed
 
+- This buildpack now installs the latest long-term support release (currently 21) of OpenJDK if no version is explicitly configured. Previously, OpenJDK 8 was installed as the default. ([#781](https://github.com/heroku/buildpacks-jvm/pull/781))
 - Some error messages have changed so they longer suggest to open a Heroku support ticket. Instead, users are now provided with a link to create an issue on GitHub. ([#674](https://github.com/heroku/buildpacks-jvm/pull/674))
 
 ### Removed

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -20,6 +20,7 @@ inventory = { git = "https://github.com/Malax/inventory", features = ["sha2"] }
 thiserror = "1"
 sha2 = "0.10"
 hex = "0.4"
+toml = "0.8"
 
 [dev-dependencies]
 buildpacks-jvm-shared-test.workspace = true

--- a/buildpacks/jvm/src/constants.rs
+++ b/buildpacks/jvm/src/constants.rs
@@ -1,3 +1,4 @@
 pub(crate) const JAVA_TOOL_OPTIONS_ENV_VAR_DELIMITER: &str = " ";
 pub(crate) const JAVA_TOOL_OPTIONS_ENV_VAR_NAME: &str = "JAVA_TOOL_OPTIONS";
 pub(crate) const JDK_OVERLAY_DIR_NAME: &str = ".jdk_overlay";
+pub(crate) const OPENJDK_LATEST_LTS_VERSION: u32 = 21;

--- a/buildpacks/jvm/src/salesforce_functions.rs
+++ b/buildpacks/jvm/src/salesforce_functions.rs
@@ -1,0 +1,22 @@
+use libcnb::read_toml_file;
+use std::path::Path;
+
+pub(crate) fn is_salesforce_function_app(app_dir: &Path) -> bool {
+    read_toml_file::<toml::value::Value>(app_dir.join("project.toml"))
+        .is_ok_and(|project_toml_table| matches!(value_at_path(&project_toml_table, &["com", "salesforce", "type"]), Some(toml::Value::String(salesforce_type)) if salesforce_type == "function"))
+}
+
+fn value_at_path<'a>(table: &'a toml::value::Value, path: &[&str]) -> Option<&'a toml::Value> {
+    let mut value = table;
+
+    for path_segment in path {
+        if let toml::Value::Table(table) = value {
+            match table.get(*path_segment) {
+                Some(next_value) => value = next_value,
+                None => return None,
+            }
+        }
+    }
+
+    Some(value)
+}

--- a/buildpacks/jvm/test-apps/java-default-app/pom.xml
+++ b/buildpacks/jvm/test-apps/java-default-app/pom.xml
@@ -1,0 +1,6 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>bogus</groupId>
+    <artifactId>bogus</artifactId>
+    <version>1.0.0</version>
+</project>

--- a/buildpacks/jvm/test-apps/salesforce-functions-app/pom.xml
+++ b/buildpacks/jvm/test-apps/salesforce-functions-app/pom.xml
@@ -1,0 +1,6 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>bogus</groupId>
+    <artifactId>bogus</artifactId>
+    <version>1.0.0</version>
+</project>

--- a/buildpacks/jvm/test-apps/salesforce-functions-app/project.toml
+++ b/buildpacks/jvm/test-apps/salesforce-functions-app/project.toml
@@ -1,0 +1,2 @@
+[com.salesforce]
+type = "function"

--- a/buildpacks/jvm/tests/integration/versions.rs
+++ b/buildpacks/jvm/tests/integration/versions.rs
@@ -1,5 +1,70 @@
 use crate::default_build_config;
-use libcnb_test::{assert_contains, TestRunner};
+use indoc::formatdoc;
+use libcnb::data::buildpack_id;
+use libcnb_test::{assert_contains, assert_not_contains, BuildpackReference, TestRunner};
+
+#[test]
+#[ignore = "integration test"]
+fn openjdk_default() {
+    TestRunner::default().build(
+        default_build_config("test-apps/java-default-app").buildpacks([
+            BuildpackReference::CurrentCrate,
+            // We need another buildpack to require 'jvm' in the build plan to be able to use a
+            // default OpenJDK version. It could be any other buildpack, heroku/maven is just
+            // convenient to use here.
+            BuildpackReference::WorkspaceBuildpack(buildpack_id!("heroku/maven")),
+        ]),
+        |context| {
+            assert_contains!(
+                context.pack_stderr,
+                &formatdoc! {"
+                    [Warning: No OpenJDK version specified]
+                    Your application does not explicitly specify an OpenJDK version. The latest
+                    long-term support (LTS) version will be installed. This currently is OpenJDK 21.
+
+                    This default version will change when a new LTS version is released. Your
+                    application might fail to build with the new version. We recommend explicitly
+                    setting the required OpenJDK version for your application.
+
+                    To set the OpenJDK version, add or edit the system.properties file in the root
+                    directory of your application to contain:
+
+                    java.runtime.version = 21
+                "}
+            );
+
+            assert_contains!(
+                context.run_shell_command("java -version").stderr,
+                "openjdk version \"21.0.3\""
+            );
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn openjdk_functions_default() {
+    TestRunner::default().build(
+        default_build_config("test-apps/salesforce-functions-app").buildpacks([
+            BuildpackReference::CurrentCrate,
+            // We need another buildpack to require 'jvm' in the build plan to be able to use a
+            // default OpenJDK version. It could be any other buildpack, heroku/maven is just
+            // convenient to use here.
+            BuildpackReference::WorkspaceBuildpack(buildpack_id!("heroku/maven")),
+        ]),
+        |context| {
+            assert_not_contains!(
+                context.pack_stderr,
+                "[Warning: No OpenJDK version specified]"
+            );
+
+            assert_contains!(
+                context.run_shell_command("java -version").stderr,
+                "openjdk version \"1.8.0_412\""
+            );
+        },
+    );
+}
 
 #[test]
 #[ignore = "integration test"]

--- a/buildpacks/maven/test-apps/simple-http-service-groovy-polyglot/system.properties
+++ b/buildpacks/maven/test-apps/simple-http-service-groovy-polyglot/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version = 8


### PR DESCRIPTION
Previously, the OpenJDK buildpack installed OpenJDK 8 when no other version was explicitly configured via `system.properties`. This PR changes the behaviour to use the latest LTS version instead of Java 8. In addition, a warning is now displayed when the default version is being used, nudging users to explicitly configure the OpenJDK version.

Since the buildpack is still used by Salesforce functions, there is a conditional that reverts back to the old policy of installing OpenJDK 8 by default if the application is detected to be a Salesforce function (via data in the `project.toml` file  that is mandatory on Salesforce functions).

## Changelog

### Added

- A warning will now be shown when the OpenJDK version is not explicitly configured for an application.

### Changed

- This buildpack now installs the latest long-term support release (currently 21) of OpenJDK if no version is explicitly configured. Previously, OpenJDK 8 was installed as the default.