### PR TITLE
Switch to the GA GitHub Actions ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,16 +70,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      # The beta ARM64 runners don't yet ship with the normal installed tools.
-      - name: Install Docker, Rust and missing development libs (ARM64 only)
-        if: matrix.arch == 'arm64'
-        run: |
-          sudo apt-get update --error-on=any
-          sudo apt-get install -y --no-install-recommends acl docker.io docker-buildx libc6-dev
-          sudo usermod -aG docker $USER
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
-          curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
       - name: Install musl-tools
         run: sudo apt-get install -y --no-install-recommends musl-tools
       - name: Update Rust toolchain


### PR DESCRIPTION
See: https://github.com/heroku/buildpacks-python/pull/204

Also accidentally ninja-ed in an update to one of the Git submodules without code changes and decided to leave it in. 