### PR TITLE
Remove stacks table from buildpack.toml files

### DIFF
--- a/buildpacks/gradle/buildpack.toml
+++ b/buildpacks/gradle/buildpack.toml
@@ -12,11 +12,6 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-# This workaround can be removed once a new Pack release ships that includes:
-# https://github.com/buildpacks/pack/pull/2081
-[[stacks]]
-id = "*"
-
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/jvm-function-invoker/buildpack.toml
+++ b/buildpacks/jvm-function-invoker/buildpack.toml
@@ -11,11 +11,6 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-# This workaround can be removed once a new Pack release ships that includes:
-# https://github.com/buildpacks/pack/pull/2081
-[[stacks]]
-id = "*"
-
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/jvm/buildpack.toml
+++ b/buildpacks/jvm/buildpack.toml
@@ -11,11 +11,6 @@ keywords = ["openjdk", "heroku"]
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-# This workaround can be removed once a new Pack release ships that includes:
-# https://github.com/buildpacks/pack/pull/2081
-[[stacks]]
-id = "*"
-
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/maven/buildpack.toml
+++ b/buildpacks/maven/buildpack.toml
@@ -12,11 +12,6 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-# This workaround can be removed once a new Pack release ships that includes:
-# https://github.com/buildpacks/pack/pull/2081
-[[stacks]]
-id = "*"
-
 [[targets]]
 os = "linux"
 arch = "amd64"

--- a/buildpacks/sbt/buildpack.toml
+++ b/buildpacks/sbt/buildpack.toml
@@ -12,11 +12,6 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-# This workaround can be removed once a new Pack release ships that includes:
-# https://github.com/buildpacks/pack/pull/2081
-[[stacks]]
-id = "*"
-
 [[targets]]
 os = "linux"
 arch = "amd64"


### PR DESCRIPTION
With the release of `pack` `v0.34.2` (GHA PR: https://github.com/heroku/buildpacks-jvm/pull/689) the previously used workaround of having a stacks table with `id = *` in each `buildpack.toml` can be finally removed.