### PR TITLE
Prevent issues with Docker Hub rate limits in CI

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   lint:
     name: Rust Code Linting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
 
   unit-test:
     name: Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
 
   integration-test:
     name: Integration Tests (${{ matrix.buildpack-directory }}, ${{matrix.builder}}, ${{matrix.arch}})
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-large' || 'pub-hk-ubuntu-22.04-large' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-large' || 'pub-hk-ubuntu-24.04-large' }}
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +80,18 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.7.2
+      # The images are pulled up front to prevent duplicate pulls due to the tests being run concurrently.
+      - name: Pull builder image
+        run: docker pull ${{ env.INTEGRATION_TEST_BUILDER }}
+      - name: Pull run image
+        # Using `docker inspect` rather than `pack builder inspect` since the latter makes
+        # additional requests to Docker Hub even when the image is available locally.
+        run: |
+          RUN_IMAGE=$(
+            docker inspect --format='{{index .Config.Labels "io.buildpacks.builder.metadata"}}' '${{ env.INTEGRATION_TEST_BUILDER }}' \
+              | jq --exit-status --raw-output '.stack.runImage.image'
+          )
+          docker pull "${RUN_IMAGE}"
       - name: Run integration tests
         working-directory: ${{ matrix.buildpack-directory }}
         # Runs only tests annotated with the `ignore` attribute (which in this repo, are the integration tests).


### PR DESCRIPTION
Switches to the new GitHub Actions runner groups to:
1. Avoid the rate limit issues mentioned in: https://github.com/heroku/buildpacks-go/pull/283
2. To update to Ubuntu 24.04

Also pre-pulls the builder and run images to prevent duplicate pulls and impact on rate limits, as mentioned in:
https://github.com/heroku/buildpacks-python/pull/223

This will resolve the rate limit errors seen here:
https://github.com/heroku/buildpacks-jvm/actions/runs/9856103370/job/27212380187#step:8:83

See also:
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZR57becb9df8d94f80b132168fd
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

GUS-W-16238120.