### PR TITLE
Migrate to struct layer API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,6 @@ version = "0.0.0"
 dependencies = [
  "indoc",
  "java-properties",
- "libcnb",
  "libherokubuildpack",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ rust-version = "1.80"
 edition = "2021"
 
 [workspace.lints.rust]
-# Temporarily allow use of deprecated items until all buildpacks migrated away
-# from the trait based layer API.
-deprecated = "allow"
 unreachable_pub = "warn"
 unsafe_code = "warn"
 unused_crate_dependencies = "warn"

--- a/buildpacks/gradle/src/layers/gradle_home.rs
+++ b/buildpacks/gradle/src/layers/gradle_home.rs
@@ -1,92 +1,75 @@
 use crate::{GradleBuildpack, GradleBuildpackError, GRADLE_TASK_NAME_HEROKU_START_DAEMON};
 use indoc::{formatdoc, indoc};
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::data::layer_name;
 use libcnb::generic::GenericMetadata;
-use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::layer::{
+    CachedLayerDefinition, InvalidMetadataAction, LayerState, RestoredLayerAction,
+};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Buildpack;
+use libcnb::Env;
 use std::fs;
-use std::path::Path;
 
-pub(crate) struct GradleHomeLayer;
-
-impl Layer for GradleHomeLayer {
-    type Buildpack = GradleBuildpack;
-    type Metadata = GenericMetadata;
-
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
-            launch: true,
+pub(crate) fn handle_gradle_home_layer(
+    context: &BuildContext<GradleBuildpack>,
+    env: &mut Env,
+) -> libcnb::Result<(), GradleBuildpackError> {
+    let layer_ref = context.cached_layer(
+        layer_name!("home"),
+        CachedLayerDefinition {
             build: true,
-            cache: true,
-        }
-    }
+            launch: true,
+            invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
+            restored_layer_action: &|_: &GenericMetadata, _| RestoredLayerAction::KeepLayer,
+        },
+    )?;
 
-    fn create(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
-        // https://docs.gradle.org/8.3/userguide/build_environment.html#sec:gradle_configuration_properties
-        fs::write(
-            layer_path.join("gradle.properties"),
-            indoc! {"
+    match layer_ref.state {
+        LayerState::Restored { .. } => {
+            // Remove daemon metadata from the cached directory. Among other things, it contains a list
+            // of PIDs from previous runs that will clutter up the output and aren't meaningful with
+            // containerized builds anyway.
+            let daemon_dir_path = layer_ref.path().join("daemon");
+            if daemon_dir_path.is_dir() {
+                // We explicitly ignore potential errors since not being able to remove this directory
+                // should not fail the build as it's mostly for output cosmetics only.
+                let _ignored_result = fs::remove_dir_all(daemon_dir_path);
+            }
+        }
+        LayerState::Empty { .. } => {
+            // https://docs.gradle.org/8.3/userguide/build_environment.html#sec:gradle_configuration_properties
+            fs::write(
+                layer_ref.path().join("gradle.properties"),
+                indoc! {"
                 org.gradle.welcome=never
                 org.gradle.caching=true
             "},
-        )
-        .map_err(GradleBuildpackError::WriteGradlePropertiesError)?;
+            )
+            .map_err(GradleBuildpackError::WriteGradlePropertiesError)?;
 
-        // We're adding this empty task to all projects to ensure we have a task we can run when
-        // we start the Gradle daemon that doesn't side-effect or output anything to the console.
-        // https://docs.gradle.org/8.3/userguide/init_scripts.html
-        fs::write(
-            layer_path.join("init.gradle.kts"),
-            formatdoc! {"
+            // We're adding this empty task to all projects to ensure we have a task we can run when
+            // we start the Gradle daemon that doesn't side-effect or output anything to the console.
+            // https://docs.gradle.org/8.3/userguide/init_scripts.html
+            fs::write(
+                layer_ref.path().join("init.gradle.kts"),
+                formatdoc! {"
                 allprojects {{
                     tasks.register(\"{task_name}\")
                 }}",
-                task_name = GRADLE_TASK_NAME_HEROKU_START_DAEMON
-            },
-        )
-        .map_err(GradleBuildpackError::WriteGradleInitScriptError)?;
+                    task_name = GRADLE_TASK_NAME_HEROKU_START_DAEMON
+                },
+            )
+            .map_err(GradleBuildpackError::WriteGradleInitScriptError)?;
 
-        LayerResultBuilder::new(None)
-            .env(LayerEnv::new().chainable_insert(
+            layer_ref.write_env(LayerEnv::new().chainable_insert(
                 Scope::All,
                 ModificationBehavior::Override,
                 "GRADLE_USER_HOME",
-                layer_path,
-            ))
-            .build()
-    }
-
-    fn existing_layer_strategy(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        _layer_data: &LayerData<Self::Metadata>,
-    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
-        Ok(ExistingLayerStrategy::Update)
-    }
-
-    fn update(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        layer_data: &LayerData<Self::Metadata>,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
-        // Remove daemon metadata from the cached directory. Among other things, it contains a list
-        // of PIDs from previous runs that will clutter up the output and aren't meaningful with
-        // containerized builds anyway.
-        let daemon_dir_path = layer_data.path.join("daemon");
-        if daemon_dir_path.is_dir() {
-            // We explicitly ignore potential errors since not being able to remove this directory
-            // should not fail the build as it's mostly for output cosmetics only.
-            let _ignored_result = fs::remove_dir_all(daemon_dir_path);
+                layer_ref.path(),
+            ))?;
         }
-
-        LayerResultBuilder::new(layer_data.content_metadata.metadata.clone())
-            .env(layer_data.env.clone())
-            .build()
     }
+
+    *env = layer_ref.read_env()?.apply(Scope::Build, env);
+    Ok(())
 }

--- a/buildpacks/gradle/src/main.rs
+++ b/buildpacks/gradle/src/main.rs
@@ -3,14 +3,13 @@ use crate::detect::is_gradle_project_directory;
 use crate::errors::on_error_gradle_buildpack;
 use crate::framework::{detect_framework, Framework};
 use crate::gradle_command::GradleCommandError;
-use crate::layers::gradle_home::GradleHomeLayer;
+use crate::layers::gradle_home::handle_gradle_home_layer;
 use crate::GradleBuildpackError::{GradleBuildIoError, GradleBuildUnexpectedStatusError};
 use buildpacks_jvm_shared as shared;
 #[cfg(test)]
 use buildpacks_jvm_shared_test as _;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::build_plan::BuildPlanBuilder;
-use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
 use libcnb::{buildpack_main, Buildpack, Env};
@@ -85,10 +84,7 @@ impl Buildpack for GradleBuildpack {
             .map_err(GradleBuildpackError::CannotSetGradleWrapperExecutableBit)?;
 
         let mut gradle_env = Env::from_current();
-        shared::env::extend_build_env(
-            context.handle_layer(layer_name!("home"), GradleHomeLayer)?,
-            &mut gradle_env,
-        );
+        handle_gradle_home_layer(&context, &mut gradle_env)?;
 
         log_header("Starting Gradle Daemon");
         gradle_command::start_daemon(&gradle_wrapper_executable_path, &gradle_env)

--- a/buildpacks/jvm-function-invoker/src/layers/bundle.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/bundle.rs
@@ -1,9 +1,8 @@
 use crate::error::JvmFunctionInvokerBuildpackError;
 use crate::JvmFunctionInvokerBuildpack;
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
-use libcnb::generic::GenericMetadata;
-use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use libcnb::data::layer_name;
+use libcnb::layer::UncachedLayerDefinition;
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::{read_toml_file, Env, TomlFileError};
 use libherokubuildpack::log::{log_header, log_info};
@@ -12,65 +11,55 @@ use std::path::Path;
 use std::process::Command;
 use thiserror::Error;
 
-pub(crate) struct BundleLayer {
-    pub(crate) env: Env,
-}
-
-impl Layer for BundleLayer {
-    type Buildpack = JvmFunctionInvokerBuildpack;
-    type Metadata = GenericMetadata;
-
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
-            launch: true,
+pub(crate) fn handle_bundle(
+    context: &BuildContext<JvmFunctionInvokerBuildpack>,
+    env: &Env,
+) -> libcnb::Result<(), JvmFunctionInvokerBuildpackError> {
+    let layer_ref = context.uncached_layer(
+        layer_name!("bundle"),
+        UncachedLayerDefinition {
             build: false,
-            cache: false,
+            launch: true,
+        },
+    )?;
+
+    log_header("Detecting function");
+
+    let invoker_jar_path = env
+        .get(crate::layers::runtime::RUNTIME_JAR_PATH_ENV_VAR_NAME)
+        .ok_or(BundleLayerError::FunctionRuntimeNotFound)?;
+
+    let exit_status = Command::new("java")
+        .args(vec![
+            "-jar",
+            &invoker_jar_path.to_string_lossy(),
+            "bundle",
+            &context.app_dir.to_string_lossy(),
+            &layer_ref.path().to_string_lossy(),
+        ])
+        .spawn()
+        .map_err(BundleLayerError::BundleCommandIoError)?
+        .wait()
+        .map_err(BundleLayerError::BundleCommandIoError)?;
+
+    match exit_status.code() {
+        Some(0) => {
+            log_function_metadata(layer_ref.path())?;
+
+            layer_ref.write_env(LayerEnv::new().chainable_insert(
+                Scope::All,
+                ModificationBehavior::Override,
+                FUNCTION_BUNDLE_DIR_ENV_VAR_NAME,
+                layer_ref.path(),
+            ))?;
         }
-    }
+        Some(1) => Err(BundleLayerError::NoFunctionsFound)?,
+        Some(2) => Err(BundleLayerError::MultipleFunctionsFound)?,
+        Some(code) => Err(BundleLayerError::DetectionFailed(code))?,
+        None => Err(BundleLayerError::UnexpectedDetectionTermination)?,
+    };
 
-    fn create(
-        &mut self,
-        context: &BuildContext<Self::Buildpack>,
-        layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, JvmFunctionInvokerBuildpackError> {
-        log_header("Detecting function");
-
-        let invoker_jar_path = self
-            .env
-            .get(crate::layers::runtime::RUNTIME_JAR_PATH_ENV_VAR_NAME)
-            .ok_or(BundleLayerError::FunctionRuntimeNotFound)?;
-
-        let exit_status = Command::new("java")
-            .args(vec![
-                "-jar",
-                &invoker_jar_path.to_string_lossy(),
-                "bundle",
-                &context.app_dir.to_string_lossy(),
-                &layer_path.to_string_lossy(),
-            ])
-            .spawn()
-            .map_err(BundleLayerError::BundleCommandIoError)?
-            .wait()
-            .map_err(BundleLayerError::BundleCommandIoError)?;
-
-        match exit_status.code() {
-            Some(0) => {
-                log_function_metadata(layer_path)?;
-                LayerResultBuilder::new(GenericMetadata::default())
-                    .env(LayerEnv::new().chainable_insert(
-                        Scope::All,
-                        ModificationBehavior::Override,
-                        FUNCTION_BUNDLE_DIR_ENV_VAR_NAME,
-                        layer_path,
-                    ))
-                    .build()
-            }
-            Some(1) => Err(BundleLayerError::NoFunctionsFound.into()),
-            Some(2) => Err(BundleLayerError::MultipleFunctionsFound.into()),
-            Some(code) => Err(BundleLayerError::DetectionFailed(code).into()),
-            None => Err(BundleLayerError::UnexpectedDetectionTermination.into()),
-        }
-    }
+    Ok(())
 }
 
 fn log_function_metadata(bundle_dir: impl AsRef<Path>) -> Result<(), BundleLayerError> {
@@ -124,6 +113,12 @@ pub(crate) enum BundleLayerError {
     BundleCommandIoError(std::io::Error),
     #[error("Could not read function bundle TOML: {0}")]
     CouldNotReadFunctionBundleToml(TomlFileError),
+}
+
+impl From<BundleLayerError> for libcnb::Error<JvmFunctionInvokerBuildpackError> {
+    fn from(value: BundleLayerError) -> Self {
+        libcnb::Error::BuildpackError(JvmFunctionInvokerBuildpackError::BundleLayerError(value))
+    }
 }
 
 const FUNCTION_BUNDLE_DIR_ENV_VAR_NAME: &str = "JVM_FUNCTION_BUNDLE_DIR";

--- a/buildpacks/jvm-function-invoker/src/layers/runtime.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/runtime.rs
@@ -1,89 +1,79 @@
 use crate::error::JvmFunctionInvokerBuildpackError;
 use crate::JvmFunctionInvokerBuildpack;
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
-use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::data::layer_name;
+use libcnb::layer::{CachedLayerDefinition, InvalidMetadataAction, RestoredLayerAction};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
+use libcnb::Env;
 use libherokubuildpack::digest::sha256;
 use libherokubuildpack::download::{download_file, DownloadError};
 use libherokubuildpack::log::log_info;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 use thiserror::Error;
 
-pub(crate) struct RuntimeLayer;
+pub(crate) fn handle_runtime(
+    context: &BuildContext<JvmFunctionInvokerBuildpack>,
+    env: &mut Env,
+) -> libcnb::Result<(), JvmFunctionInvokerBuildpackError> {
+    let layer_ref = context.cached_layer(
+        layer_name!("runtime"),
+        CachedLayerDefinition {
+            build: false,
+            launch: true,
+            invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
+            restored_layer_action: &|metadata: &RuntimeLayerMetadata, _| {
+                let sha256_matches = metadata.installed_runtime_sha256
+                    == context.buildpack_descriptor.metadata.runtime.sha256;
+
+                if sha256_matches {
+                    log_info("Using cached Java function runtime from previous build.");
+                    RestoredLayerAction::KeepLayer
+                } else {
+                    RestoredLayerAction::DeleteLayer
+                }
+            },
+        },
+    )?;
+
+    log_info("Starting download of function runtime");
+
+    let runtime_jar_path = layer_ref.path().join("sf-fx-runtime-java.jar");
+
+    download_file(
+        &context.buildpack_descriptor.metadata.runtime.url,
+        &runtime_jar_path,
+    )
+    .map_err(RuntimeLayerError::DownloadFailed)?;
+
+    log_info("Function runtime download successful");
+
+    let actual_runtime_jar_sha256 =
+        sha256(&runtime_jar_path).map_err(RuntimeLayerError::ChecksumFailed)?;
+
+    if actual_runtime_jar_sha256 == context.buildpack_descriptor.metadata.runtime.sha256 {
+        layer_ref.write_metadata(RuntimeLayerMetadata {
+            installed_runtime_sha256: actual_runtime_jar_sha256,
+        })?;
+
+        layer_ref.write_env(LayerEnv::new().chainable_insert(
+            Scope::All,
+            ModificationBehavior::Override,
+            RUNTIME_JAR_PATH_ENV_VAR_NAME,
+            runtime_jar_path,
+        ))?;
+    } else {
+        Err(RuntimeLayerError::ChecksumMismatch(
+            actual_runtime_jar_sha256,
+        ))?;
+    }
+
+    *env = layer_ref.read_env()?.apply(Scope::Build, env);
+    Ok(())
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct RuntimeLayerMetadata {
     installed_runtime_sha256: String,
-}
-
-impl Layer for RuntimeLayer {
-    type Buildpack = JvmFunctionInvokerBuildpack;
-    type Metadata = RuntimeLayerMetadata;
-
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
-            launch: true,
-            build: false,
-            cache: true,
-        }
-    }
-
-    fn create(
-        &mut self,
-        context: &BuildContext<Self::Buildpack>,
-        layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, JvmFunctionInvokerBuildpackError> {
-        log_info("Starting download of function runtime");
-
-        let runtime_jar_path = layer_path.join("sf-fx-runtime-java.jar");
-
-        download_file(
-            &context.buildpack_descriptor.metadata.runtime.url,
-            &runtime_jar_path,
-        )
-        .map_err(RuntimeLayerError::DownloadFailed)?;
-
-        log_info("Function runtime download successful");
-
-        let actual_runtime_jar_sha256 =
-            sha256(&runtime_jar_path).map_err(RuntimeLayerError::ChecksumFailed)?;
-
-        if actual_runtime_jar_sha256 == context.buildpack_descriptor.metadata.runtime.sha256 {
-            LayerResultBuilder::new(RuntimeLayerMetadata {
-                installed_runtime_sha256: actual_runtime_jar_sha256,
-            })
-            .env(LayerEnv::new().chainable_insert(
-                Scope::All,
-                ModificationBehavior::Override,
-                RUNTIME_JAR_PATH_ENV_VAR_NAME,
-                runtime_jar_path,
-            ))
-            .build()
-        } else {
-            Err(RuntimeLayerError::ChecksumMismatch(actual_runtime_jar_sha256).into())
-        }
-    }
-
-    fn existing_layer_strategy(
-        &mut self,
-        context: &BuildContext<Self::Buildpack>,
-        layer_data: &LayerData<Self::Metadata>,
-    ) -> Result<ExistingLayerStrategy, JvmFunctionInvokerBuildpackError> {
-        let sha256_matches = layer_data
-            .content_metadata
-            .metadata
-            .installed_runtime_sha256
-            == context.buildpack_descriptor.metadata.runtime.sha256;
-
-        if sha256_matches {
-            log_info("Using cached Java function runtime from previous build.");
-            Ok(ExistingLayerStrategy::Keep)
-        } else {
-            Ok(ExistingLayerStrategy::Recreate)
-        }
-    }
 }
 
 #[derive(Error, Debug)]
@@ -96,6 +86,12 @@ pub(crate) enum RuntimeLayerError {
 
     #[error("Checksum validation of runtime JAR failed! Checksum was: {0}")]
     ChecksumMismatch(String),
+}
+
+impl From<RuntimeLayerError> for libcnb::Error<JvmFunctionInvokerBuildpackError> {
+    fn from(value: RuntimeLayerError) -> Self {
+        libcnb::Error::BuildpackError(JvmFunctionInvokerBuildpackError::RuntimeLayerError(value))
+    }
 }
 
 pub(crate) const RUNTIME_JAR_PATH_ENV_VAR_NAME: &str = "JVM_FUNCTION_RUNTIME_JAR_PATH";

--- a/buildpacks/jvm/src/layers/openjdk.rs
+++ b/buildpacks/jvm/src/layers/openjdk.rs
@@ -9,175 +9,171 @@ use fs_extra::dir::CopyOptions;
 use inventory::artifact::Artifact;
 use libcnb::additional_buildpack_binary_path;
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
-use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::data::layer_name;
+use libcnb::layer::{
+    CachedLayerDefinition, InvalidMetadataAction, LayerState, RestoredLayerAction,
+};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use serde::Deserialize;
 use serde::Serialize;
 use sha2::Sha256;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tempfile::tempdir;
 
-pub(crate) struct OpenJdkLayer<'a> {
-    pub(crate) artifact: &'a Artifact<OpenJdkVersion, Sha256, OpenJdkArtifactMetadata>,
+#[allow(clippy::too_many_lines)]
+pub(crate) fn handle_openjdk_layer(
+    context: &BuildContext<OpenJdkBuildpack>,
+    artifact: &Artifact<OpenJdkVersion, Sha256, OpenJdkArtifactMetadata>,
+) -> libcnb::Result<(), OpenJdkBuildpackError> {
+    let layer_ref = context.cached_layer(
+        layer_name!("openjdk"),
+        CachedLayerDefinition {
+            build: true,
+            launch: true,
+            invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
+            restored_layer_action: &|metadata: &OpenJdkLayerMetadata, _| {
+                if context.app_dir.join(JDK_OVERLAY_DIR_NAME).exists()
+                    || metadata.jdk_overlay_applied
+                {
+                    // Since the JDK overlay will modify the OpenJDK distribution and the cached version
+                    // might already have an (potentially different) overlay applied, we re-crate the layer
+                    // in that case.
+                    RestoredLayerAction::DeleteLayer
+                } else if artifact.url == metadata.source_tarball_url {
+                    RestoredLayerAction::KeepLayer
+                } else {
+                    RestoredLayerAction::DeleteLayer
+                }
+            },
+        },
+    )?;
+
+    match layer_ref.state {
+        LayerState::Restored { .. } => {}
+        LayerState::Empty { .. } => {
+            libherokubuildpack::log::log_header(format!("Installing OpenJDK {}", artifact.version));
+
+            let temp_dir = tempdir().map_err(OpenJdkBuildpackError::CannotCreateOpenJdkTempDir)?;
+            let path = temp_dir.path().join("openjdk.tar.gz");
+
+            libherokubuildpack::download::download_file(&artifact.url, &path)
+                .map_err(OpenJdkBuildpackError::OpenJdkDownloadError)?;
+
+            std::fs::File::open(&path)
+                .map_err(OpenJdkBuildpackError::CannotReadOpenJdkTarball)
+                .and_then(|file| {
+                    digest::<Sha256>(file).map_err(OpenJdkBuildpackError::CannotReadOpenJdkTarball)
+                })
+                .and_then(|downloaded_file_digest| {
+                    if downloaded_file_digest.as_slice() == artifact.checksum.value {
+                        Ok(())
+                    } else {
+                        Err(OpenJdkBuildpackError::OpenJdkTarballChecksumError {
+                            expected: artifact.checksum.value.clone(),
+                            actual: downloaded_file_digest.to_vec(),
+                        })
+                    }
+                })?;
+
+            std::fs::File::open(&path)
+                .map_err(OpenJdkBuildpackError::CannotReadOpenJdkTarball)
+                .and_then(|mut file| {
+                    libherokubuildpack::tar::decompress_tarball(&mut file, layer_ref.path())
+                        .map_err(OpenJdkBuildpackError::CannotDecompressOpenJdkTarball)
+                })?;
+
+            let app_jdk_overlay_dir_path = context.app_dir.join(JDK_OVERLAY_DIR_NAME);
+
+            let ubuntu_java_cacerts_file_path = PathBuf::from("/etc/ssl/certs/java/cacerts");
+
+            // Depending on OpenJDK version, the path for the cacerts file can differ.
+            let relative_jdk_cacerts_path = ["jre/lib/security/cacerts", "lib/security/cacerts"]
+                .iter()
+                .find(|path| layer_ref.path().join(path).is_file())
+                .ok_or(OpenJdkBuildpackError::MissingJdkCertificatesFile)?;
+
+            let symlink_ubuntu_java_cacerts_file = ubuntu_java_cacerts_file_path.is_file()
+                && !app_jdk_overlay_dir_path
+                    .join(relative_jdk_cacerts_path)
+                    .exists();
+
+            if symlink_ubuntu_java_cacerts_file {
+                let absolute_jdk_cacerts_path = layer_ref.path().join(relative_jdk_cacerts_path);
+
+                std::fs::rename(
+                    &absolute_jdk_cacerts_path,
+                    absolute_jdk_cacerts_path.with_extension("old"),
+                )
+                .map_err(OpenJdkBuildpackError::CannotSymlinkUbuntuCertificates)?;
+
+                // We symlink instead of copying to ensure cacerts is always the latest version,
+                // even when the image is rebased.
+                std::os::unix::fs::symlink(
+                    ubuntu_java_cacerts_file_path,
+                    absolute_jdk_cacerts_path,
+                )
+                .map_err(OpenJdkBuildpackError::CannotSymlinkUbuntuCertificates)?;
+            }
+
+            let mut jdk_overlay_applied = false;
+            if app_jdk_overlay_dir_path.is_dir() {
+                jdk_overlay_applied = true;
+
+                let jdk_overlay_contents = util::list_directory_contents(&app_jdk_overlay_dir_path)
+                    .map_err(OpenJdkBuildpackError::CannotListJdkOverlayContents)?;
+
+                fs_extra::copy_items(
+                    &jdk_overlay_contents,
+                    layer_ref.path(),
+                    &CopyOptions {
+                        overwrite: true,
+                        skip_exist: false,
+                        copy_inside: true,
+                        ..CopyOptions::default()
+                    },
+                )
+                .map_err(OpenJdkBuildpackError::CannotCopyJdkOverlayContents)?;
+            }
+
+            layer_ref.write_metadata(OpenJdkLayerMetadata {
+                source_tarball_url: artifact.url.clone(),
+                jdk_overlay_applied,
+            })?;
+
+            layer_ref.write_env(
+                LayerEnv::new()
+                    .chainable_insert(
+                        Scope::All,
+                        ModificationBehavior::Override,
+                        "JAVA_HOME",
+                        layer_ref.path(),
+                    )
+                    .chainable_insert(
+                        Scope::All,
+                        ModificationBehavior::Delimiter,
+                        JAVA_TOOL_OPTIONS_ENV_VAR_NAME,
+                        JAVA_TOOL_OPTIONS_ENV_VAR_DELIMITER,
+                    )
+                    .chainable_insert(
+                        Scope::All,
+                        ModificationBehavior::Prepend,
+                        JAVA_TOOL_OPTIONS_ENV_VAR_NAME,
+                        "-Dfile.encoding=UTF-8",
+                    ),
+            )?;
+
+            layer_ref.write_exec_d_programs([(
+                "heroku_dynamic_jvm_opts",
+                additional_buildpack_binary_path!("heroku_dynamic_jvm_opts"),
+            )])?;
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct OpenJdkLayerMetadata {
     jdk_overlay_applied: bool,
     source_tarball_url: String,
-}
-
-impl<'a> Layer for OpenJdkLayer<'a> {
-    type Buildpack = OpenJdkBuildpack;
-    type Metadata = OpenJdkLayerMetadata;
-
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
-            launch: true,
-            build: true,
-            cache: true,
-        }
-    }
-
-    fn create(
-        &mut self,
-        context: &BuildContext<Self::Buildpack>,
-        layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, OpenJdkBuildpackError> {
-        libherokubuildpack::log::log_header(format!(
-            "Installing OpenJDK {}",
-            self.artifact.version
-        ));
-
-        let temp_dir = tempdir().map_err(OpenJdkBuildpackError::CannotCreateOpenJdkTempDir)?;
-        let path = temp_dir.path().join("openjdk.tar.gz");
-
-        libherokubuildpack::download::download_file(&self.artifact.url, &path)
-            .map_err(OpenJdkBuildpackError::OpenJdkDownloadError)?;
-
-        std::fs::File::open(&path)
-            .map_err(OpenJdkBuildpackError::CannotReadOpenJdkTarball)
-            .and_then(|file| {
-                digest::<Sha256>(file).map_err(OpenJdkBuildpackError::CannotReadOpenJdkTarball)
-            })
-            .and_then(|downloaded_file_digest| {
-                if downloaded_file_digest.as_slice() == self.artifact.checksum.value {
-                    Ok(())
-                } else {
-                    Err(OpenJdkBuildpackError::OpenJdkTarballChecksumError {
-                        expected: self.artifact.checksum.value.clone(),
-                        actual: downloaded_file_digest.to_vec(),
-                    })
-                }
-            })?;
-
-        std::fs::File::open(&path)
-            .map_err(OpenJdkBuildpackError::CannotReadOpenJdkTarball)
-            .and_then(|mut file| {
-                libherokubuildpack::tar::decompress_tarball(&mut file, layer_path)
-                    .map_err(OpenJdkBuildpackError::CannotDecompressOpenJdkTarball)
-            })?;
-
-        let app_jdk_overlay_dir_path = context.app_dir.join(JDK_OVERLAY_DIR_NAME);
-
-        let ubuntu_java_cacerts_file_path = PathBuf::from("/etc/ssl/certs/java/cacerts");
-
-        // Depending on OpenJDK version, the path for the cacerts file can differ.
-        let relative_jdk_cacerts_path = ["jre/lib/security/cacerts", "lib/security/cacerts"]
-            .iter()
-            .find(|path| layer_path.join(path).is_file())
-            .ok_or(OpenJdkBuildpackError::MissingJdkCertificatesFile)?;
-
-        let symlink_ubuntu_java_cacerts_file = ubuntu_java_cacerts_file_path.is_file()
-            && !app_jdk_overlay_dir_path
-                .join(relative_jdk_cacerts_path)
-                .exists();
-
-        if symlink_ubuntu_java_cacerts_file {
-            let absolute_jdk_cacerts_path = layer_path.join(relative_jdk_cacerts_path);
-
-            fs::rename(
-                &absolute_jdk_cacerts_path,
-                absolute_jdk_cacerts_path.with_extension("old"),
-            )
-            .map_err(OpenJdkBuildpackError::CannotSymlinkUbuntuCertificates)?;
-
-            // We symlink instead of copying to ensure cacerts is always the latest version,
-            // even when the image is rebased.
-            std::os::unix::fs::symlink(ubuntu_java_cacerts_file_path, absolute_jdk_cacerts_path)
-                .map_err(OpenJdkBuildpackError::CannotSymlinkUbuntuCertificates)?;
-        }
-
-        let mut jdk_overlay_applied = false;
-        if app_jdk_overlay_dir_path.is_dir() {
-            jdk_overlay_applied = true;
-
-            let jdk_overlay_contents = util::list_directory_contents(&app_jdk_overlay_dir_path)
-                .map_err(OpenJdkBuildpackError::CannotListJdkOverlayContents)?;
-
-            fs_extra::copy_items(
-                &jdk_overlay_contents,
-                layer_path,
-                &CopyOptions {
-                    overwrite: true,
-                    skip_exist: false,
-                    copy_inside: true,
-                    ..CopyOptions::default()
-                },
-            )
-            .map_err(OpenJdkBuildpackError::CannotCopyJdkOverlayContents)?;
-        }
-
-        LayerResultBuilder::new(OpenJdkLayerMetadata {
-            source_tarball_url: self.artifact.url.clone(),
-            jdk_overlay_applied,
-        })
-        .env(
-            LayerEnv::new()
-                .chainable_insert(
-                    Scope::All,
-                    ModificationBehavior::Override,
-                    "JAVA_HOME",
-                    layer_path,
-                )
-                .chainable_insert(
-                    Scope::All,
-                    ModificationBehavior::Delimiter,
-                    JAVA_TOOL_OPTIONS_ENV_VAR_NAME,
-                    JAVA_TOOL_OPTIONS_ENV_VAR_DELIMITER,
-                )
-                .chainable_insert(
-                    Scope::All,
-                    ModificationBehavior::Prepend,
-                    JAVA_TOOL_OPTIONS_ENV_VAR_NAME,
-                    "-Dfile.encoding=UTF-8",
-                ),
-        )
-        .exec_d_program(
-            "heroku_dynamic_jvm_opts",
-            additional_buildpack_binary_path!("heroku_dynamic_jvm_opts"),
-        )
-        .build()
-    }
-
-    fn existing_layer_strategy(
-        &mut self,
-        context: &BuildContext<Self::Buildpack>,
-        layer_data: &LayerData<Self::Metadata>,
-    ) -> Result<ExistingLayerStrategy, OpenJdkBuildpackError> {
-        if context.app_dir.join(JDK_OVERLAY_DIR_NAME).exists()
-            || layer_data.content_metadata.metadata.jdk_overlay_applied
-        {
-            // Since the JDK overlay will modify the OpenJDK distribution and the cached version
-            // might already have an (potentially different) overlay applied, we re-crate the layer
-            // in that case.
-            Ok(ExistingLayerStrategy::Recreate)
-        } else if self.artifact.url == layer_data.content_metadata.metadata.source_tarball_url {
-            Ok(ExistingLayerStrategy::Keep)
-        } else {
-            Ok(ExistingLayerStrategy::Recreate)
-        }
-    }
 }

--- a/buildpacks/jvm/src/layers/runtime.rs
+++ b/buildpacks/jvm/src/layers/runtime.rs
@@ -1,35 +1,22 @@
-use crate::OpenJdkBuildpack;
+use crate::{OpenJdkBuildpack, OpenJdkBuildpackError};
+use libcnb::additional_buildpack_binary_path;
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
-use libcnb::generic::GenericMetadata;
-use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
-use libcnb::{additional_buildpack_binary_path, Buildpack};
-use std::path::Path;
+use libcnb::data::layer_name;
+use libcnb::layer::UncachedLayerDefinition;
 
-pub(crate) struct RuntimeLayer;
-
-impl Layer for RuntimeLayer {
-    type Buildpack = OpenJdkBuildpack;
-    type Metadata = GenericMetadata;
-
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
+pub(crate) fn handle_runtime_layer(
+    context: &BuildContext<OpenJdkBuildpack>,
+) -> libcnb::Result<(), OpenJdkBuildpackError> {
+    let layer_ref = context.uncached_layer(
+        layer_name!("runtime"),
+        UncachedLayerDefinition {
             build: false,
             launch: true,
-            cache: false,
-        }
-    }
+        },
+    )?;
 
-    fn create(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        _layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
-        LayerResultBuilder::new(GenericMetadata::default())
-            .exec_d_program(
-                "heroku_database_env_var_rewrite",
-                additional_buildpack_binary_path!("heroku_database_env_var_rewrite"),
-            )
-            .build()
-    }
+    layer_ref.write_exec_d_programs([(
+        "heroku_database_env_var_rewrite",
+        additional_buildpack_binary_path!("heroku_database_env_var_rewrite"),
+    )])
 }

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -8,8 +8,8 @@ mod util;
 
 use crate::constants::OPENJDK_LATEST_LTS_VERSION;
 use crate::errors::on_error_jvm_buildpack;
-use crate::layers::openjdk::OpenJdkLayer;
-use crate::layers::runtime::RuntimeLayer;
+use crate::layers::openjdk::handle_openjdk_layer;
+use crate::layers::runtime::handle_runtime_layer;
 use crate::openjdk_artifact::{
     HerokuOpenJdkVersionRequirement, OpenJdkArtifactMetadata, OpenJdkArtifactRequirement,
     OpenJdkArtifactRequirementParseError, OpenJdkDistribution,
@@ -28,7 +28,6 @@ use inventory::inventory::{Inventory, ParseInventoryError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::buildpack_main;
 use libcnb::data::build_plan::BuildPlanBuilder;
-use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::Buildpack;
@@ -164,14 +163,8 @@ impl Buildpack for OpenJdkBuildpack {
                 openjdk_artifact_requirement,
             ))?;
 
-        context.handle_layer(
-            layer_name!("openjdk"),
-            OpenJdkLayer {
-                artifact: openjdk_artifact,
-            },
-        )?;
-
-        context.handle_layer(layer_name!("runtime"), RuntimeLayer)?;
+        handle_openjdk_layer(&context, openjdk_artifact)?;
+        handle_runtime_layer(&context)?;
 
         BuildResultBuilder::new().build()
     }

--- a/buildpacks/maven/src/layer/maven.rs
+++ b/buildpacks/maven/src/layer/maven.rs
@@ -1,63 +1,60 @@
 use crate::util::extract_tarball;
 use crate::{MavenBuildpack, MavenBuildpackError, Tarball};
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
-use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::data::layer_name;
+use libcnb::layer::{
+    CachedLayerDefinition, InvalidMetadataAction, LayerState, RestoredLayerAction,
+};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Buildpack;
+use libcnb::Env;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::path::Path;
 
-pub(crate) struct MavenLayer {
-    pub(crate) tarball: Tarball,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct MavenLayerMetadata {
-    tarball: Tarball,
-}
-
-impl Layer for MavenLayer {
-    type Buildpack = MavenBuildpack;
-    type Metadata = MavenLayerMetadata;
-
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
-            launch: true,
+pub(crate) fn handle_maven_layer(
+    context: &BuildContext<MavenBuildpack>,
+    tarball: &Tarball,
+    env: &mut Env,
+) -> libcnb::Result<(), MavenBuildpackError> {
+    let layer_ref = context.cached_layer(
+        layer_name!("maven"),
+        CachedLayerDefinition {
             build: true,
-            cache: true,
-        }
-    }
+            launch: true,
+            invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
+            restored_layer_action: &|metadata: &MavenLayerMetadata, _| {
+                if &metadata.tarball == tarball {
+                    RestoredLayerAction::KeepLayer
+                } else {
+                    RestoredLayerAction::DeleteLayer
+                }
+            },
+        },
+    )?;
 
-    fn create(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+    if let LayerState::Empty { .. } = layer_ref.state {
         let temp_dir = tempfile::tempdir()
             .map_err(MavenBuildpackError::MavenTarballCreateTemporaryDirectoryError)?;
 
         let temp_file_path = temp_dir.path().join("maven.tar.gz");
 
-        libherokubuildpack::download::download_file(&self.tarball.url, &temp_file_path)
+        libherokubuildpack::download::download_file(&tarball.url, &temp_file_path)
             .map_err(MavenBuildpackError::MavenTarballDownloadError)?;
 
         libherokubuildpack::digest::sha256(&temp_file_path)
             .map_err(MavenBuildpackError::MavenTarballSha256IoError)
             .and_then(|downloaded_tarball_sha256| {
-                if downloaded_tarball_sha256 == self.tarball.sha256 {
+                if downloaded_tarball_sha256 == tarball.sha256 {
                     Ok(())
                 } else {
                     Err(MavenBuildpackError::MavenTarballSha256Mismatch {
-                        expected_sha256: self.tarball.sha256.clone(),
+                        expected_sha256: tarball.sha256.clone(),
                         actual_sha256: downloaded_tarball_sha256,
                     })
                 }
             })?;
 
         File::open(&temp_file_path)
-            .and_then(|mut file| extract_tarball(&mut file, layer_path, 1))
+            .and_then(|mut file| extract_tarball(&mut file, &layer_ref.path(), 1))
             .map_err(MavenBuildpackError::MavenTarballDecompressError)?;
 
         // Even though M2_HOME is no longer supported by Maven versions >= 3.5.0, other tooling such
@@ -68,27 +65,21 @@ impl Layer for MavenLayer {
             Scope::Build,
             ModificationBehavior::Override,
             "M2_HOME",
-            layer_path,
+            layer_ref.path(),
         );
 
-        LayerResultBuilder::new(MavenLayerMetadata {
-            tarball: self.tarball.clone(),
-        })
-        .env(layer_env)
-        .build()
+        layer_ref.write_env(layer_env)?;
+        layer_ref.write_metadata(MavenLayerMetadata {
+            tarball: tarball.clone(),
+        })?;
     }
 
-    fn existing_layer_strategy(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        layer_data: &LayerData<Self::Metadata>,
-    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
-        let strategy = if layer_data.content_metadata.metadata.tarball == self.tarball {
-            ExistingLayerStrategy::Keep
-        } else {
-            ExistingLayerStrategy::Recreate
-        };
+    *env = layer_ref.read_env()?.apply(Scope::Build, env);
 
-        Ok(strategy)
-    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MavenLayerMetadata {
+    tarball: Tarball,
 }

--- a/buildpacks/maven/src/layer/maven_repo.rs
+++ b/buildpacks/maven/src/layer/maven_repo.rs
@@ -1,55 +1,41 @@
-use crate::MavenBuildpack;
+use crate::{MavenBuildpack, MavenBuildpackError};
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::data::layer_name;
 use libcnb::generic::GenericMetadata;
-use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::layer::{CachedLayerDefinition, InvalidMetadataAction, RestoredLayerAction};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Buildpack;
-use std::path::Path;
+use libcnb::Env;
 
-pub(crate) struct MavenRepositoryLayer;
-
-impl Layer for MavenRepositoryLayer {
-    type Buildpack = MavenBuildpack;
-    type Metadata = GenericMetadata;
-
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
-            build: true,
+pub(crate) fn handle_maven_repository_layer(
+    context: &BuildContext<MavenBuildpack>,
+    env: &mut Env,
+) -> libcnb::Result<(), MavenBuildpackError> {
+    let layer_ref = context.cached_layer(
+        layer_name!("repository"),
+        CachedLayerDefinition {
+            build: false,
             launch: false,
-            cache: true,
-        }
-    }
+            invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
+            restored_layer_action: &|_: &GenericMetadata, _| RestoredLayerAction::KeepLayer,
+        },
+    )?;
 
-    fn create(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
-        LayerResultBuilder::new(GenericMetadata::default())
-            .env(
-                LayerEnv::new()
-                    .chainable_insert(
-                        Scope::Build,
-                        ModificationBehavior::Delimiter,
-                        "MAVEN_OPTS",
-                        " ",
-                    )
-                    .chainable_insert(
-                        Scope::Build,
-                        ModificationBehavior::Append,
-                        "MAVEN_OPTS",
-                        format!("-Dmaven.repo.local={}", &layer_path.to_string_lossy()),
-                    ),
+    layer_ref.write_env(
+        LayerEnv::new()
+            .chainable_insert(
+                Scope::Build,
+                ModificationBehavior::Delimiter,
+                "MAVEN_OPTS",
+                " ",
             )
-            .build()
-    }
+            .chainable_insert(
+                Scope::Build,
+                ModificationBehavior::Append,
+                "MAVEN_OPTS",
+                format!("-Dmaven.repo.local={}", &layer_ref.path().to_string_lossy()),
+            ),
+    )?;
 
-    fn existing_layer_strategy(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        _layer_data: &LayerData<Self::Metadata>,
-    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
-        Ok(ExistingLayerStrategy::Keep)
-    }
+    *env = layer_ref.read_env()?.apply(Scope::Build, env);
+    Ok(())
 }

--- a/buildpacks/sbt/src/layers/sbt_global.rs
+++ b/buildpacks/sbt/src/layers/sbt_global.rs
@@ -1,86 +1,72 @@
 use crate::errors::SbtBuildpackError;
 use crate::SbtBuildpack;
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
-use libcnb::generic::GenericMetadata;
-use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use libcnb::data::layer_name;
+use libcnb::layer::UncachedLayerDefinition;
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Buildpack;
+use libcnb::Env;
 use std::fs;
-use std::path::Path;
 
-pub(crate) struct SbtGlobalLayer {
-    pub(crate) available_at_launch: bool,
-}
+pub(crate) fn handle_sbt_global(
+    context: &BuildContext<SbtBuildpack>,
+    available_at_launch: bool,
+    env: &mut Env,
+) -> libcnb::Result<(), SbtBuildpackError> {
+    let layer_ref = context.uncached_layer(
+        layer_name!("sbt-global"),
+        UncachedLayerDefinition {
+            build: false,
+            launch: available_at_launch,
+        },
+    )?;
 
-impl Layer for SbtGlobalLayer {
-    type Buildpack = SbtBuildpack;
-    type Metadata = GenericMetadata;
+    let plugin_path = layer_ref
+        .path()
+        .join("plugins")
+        .join("HerokuBuildpackPlugin.scala");
 
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
-            build: true,
-            launch: self.available_at_launch,
-            cache: false,
-        }
+    if let Some(plugin_path_parent) = plugin_path.parent() {
+        fs::create_dir_all(plugin_path_parent).map_err(|error| {
+            SbtBuildpackError::SbtGlobalLayerError(SbtGlobalLayerError::CouldNotWritePlugin(error))
+        })?;
     }
 
-    fn create(
-        &mut self,
-        _context: &BuildContext<Self::Buildpack>,
-        layer_path: &Path,
-    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
-        let plugin_path = layer_path
-            .join("plugins")
-            .join("HerokuBuildpackPlugin.scala");
+    fs::write(
+        plugin_path,
+        include_bytes!("../../sbt-plugins/buildpack-plugin-1.x.scala"),
+    )
+    .map_err(|error| {
+        SbtBuildpackError::SbtGlobalLayerError(SbtGlobalLayerError::CouldNotWritePlugin(error))
+    })?;
 
-        if let Some(plugin_path_parent) = plugin_path.parent() {
-            fs::create_dir_all(plugin_path_parent)
-                .map_err(SbtGlobalLayerError::CouldNotWritePlugin)?;
-        }
-
-        fs::write(
-            plugin_path,
-            include_bytes!("../../sbt-plugins/buildpack-plugin-1.x.scala"),
-        )
-        .map_err(SbtGlobalLayerError::CouldNotWritePlugin)?;
-
-        LayerResultBuilder::new(GenericMetadata::default())
-            .env(
-                LayerEnv::new()
-                    .chainable_insert(
-                        get_layer_env_scope(self.available_at_launch),
-                        ModificationBehavior::Delimiter,
-                        "SBT_OPTS",
-                        " ",
-                    )
-                    .chainable_insert(
-                        get_layer_env_scope(self.available_at_launch),
-                        ModificationBehavior::Append,
-                        "SBT_OPTS",
-                        // See: https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html
-                        format!("-Dsbt.global.base={}", layer_path.to_string_lossy()),
-                    ),
-            )
-            .build()
-    }
-}
-
-fn get_layer_env_scope(available_at_launch: bool) -> Scope {
-    if available_at_launch {
+    let env_scope = if available_at_launch {
         Scope::All
     } else {
         Scope::Build
-    }
+    };
+
+    layer_ref.write_env(
+        LayerEnv::new()
+            .chainable_insert(
+                env_scope.clone(),
+                ModificationBehavior::Delimiter,
+                "SBT_OPTS",
+                " ",
+            )
+            .chainable_insert(
+                env_scope,
+                ModificationBehavior::Append,
+                "SBT_OPTS",
+                // See: https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html
+                format!("-Dsbt.global.base={}", layer_ref.path().to_string_lossy()),
+            ),
+    )?;
+
+    *env = layer_ref.read_env()?.apply(Scope::Build, env);
+    Ok(())
 }
 
 #[derive(Debug)]
 pub(crate) enum SbtGlobalLayerError {
     CouldNotWritePlugin(std::io::Error),
-}
-
-impl From<SbtGlobalLayerError> for SbtBuildpackError {
-    fn from(value: SbtGlobalLayerError) -> Self {
-        SbtBuildpackError::SbtGlobalLayerError(value)
-    }
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,5 +9,4 @@ workspace = true
 [dependencies]
 indoc = "2"
 java-properties = "2"
-libcnb = "=0.23.0"
 libherokubuildpack = { version = "=0.23.0", default-features = false, features = ["log"] }

--- a/shared/src/env.rs
+++ b/shared/src/env.rs
@@ -1,8 +1,0 @@
-use libcnb::layer::LayerData;
-use libcnb::layer_env::Scope;
-use libcnb::Env;
-
-pub fn extend_build_env<T>(value: LayerData<T>, env: &mut Env) -> LayerData<T> {
-    *env = value.env.apply(Scope::Build, env);
-    value
-}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod env;
 pub mod fs;
 pub mod log;
 pub mod result;


### PR DESCRIPTION
A straightforward port of the existing layer implementations to the new struct-based API. Potential improvements to the layer implementations that are now possible with the new API are not part of the PR.