### PR TITLE
Add Git submodule directories to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 
 # However, request review from the language owner instead for files that are updated
 # by Dependabot or release automation, to reduce team review request noise.
+/buildpacks/*/test-apps/heroku-*-getting-started/ @Malax
+/buildpacks/sbt/sbt-extras/ @Malax
 buildpack.toml @Malax
 CHANGELOG.md @Malax
 Cargo.toml @Malax


### PR DESCRIPTION
To prevent team review requests for Dependabot PRs like:
- https://github.com/heroku/buildpacks-jvm/pull/712
- https://github.com/heroku/buildpacks-jvm/pull/722
- https://github.com/heroku/buildpacks-jvm/pull/723
- https://github.com/heroku/buildpacks-jvm/pull/724