### PR TITLE
Update CODEOWNERS for Git submodules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 
 # However, request review from the language owner instead for files that are updated
 # by Dependabot or release automation, to reduce team review request noise.
-/buildpacks/*/test-apps/heroku-*-getting-started/ @Malax
-/buildpacks/sbt/sbt-extras/ @Malax
+/buildpacks/*/test-apps/heroku-*-getting-started @Malax
+/buildpacks/sbt/sbt-extras @Malax
 buildpack.toml @Malax
 CHANGELOG.md @Malax
 Cargo.toml @Malax


### PR DESCRIPTION
In #725 the Git submodules directories were added to CODEOWNERS to try and reduce PR review noise.

However, the languages team alias was still requested for review in #733 and #734.

I suspect this might be due to the trailing slash for these entries in CODEOWNERS - since if you look at the diff view for one of those PRs, they are unsurprisingly tracked as a flat file with a reference, not a directory, eg:
https://patch-diff.githubusercontent.com/raw/heroku/buildpacks-jvm/pull/733.diff