### PR TITLE
Use `heroku/builder:24` in README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build a JVM application codebase into a production image:
 
 ```bash
 $ cd ~/workdir/sample-jvm-app
-$ pack build sample-app --builder heroku/builder:22
+$ pack build sample-app --builder heroku/builder:24
 ```
 
 Then run the image:


### PR DESCRIPTION
For multi-arch support + now that Heroku-24 is the default stack instead of Heroku-22.