### PR TITLE
Fix JDK overlay directory, add tests

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- JDK overlays are now properly sourced from the `.jdk-overlay` directory instead of `.jdk_overlay`. ([#763](https://github.com/heroku/buildpacks-jvm/pull/763))
+
 ## [6.0.4] - 2024-12-05
 
 ### Added

--- a/buildpacks/jvm/src/constants.rs
+++ b/buildpacks/jvm/src/constants.rs
@@ -1,4 +1,4 @@
 pub(crate) const JAVA_TOOL_OPTIONS_ENV_VAR_DELIMITER: &str = " ";
 pub(crate) const JAVA_TOOL_OPTIONS_ENV_VAR_NAME: &str = "JAVA_TOOL_OPTIONS";
-pub(crate) const JDK_OVERLAY_DIR_NAME: &str = ".jdk_overlay";
+pub(crate) const JDK_OVERLAY_DIR_NAME: &str = ".jdk-overlay";
 pub(crate) const OPENJDK_LATEST_LTS_VERSION: u32 = 21;

--- a/buildpacks/jvm/tests/integration/main.rs
+++ b/buildpacks/jvm/tests/integration/main.rs
@@ -11,6 +11,7 @@
 use libcnb_test::BuildConfig;
 use std::path::Path;
 
+mod overlay;
 mod versions;
 
 fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {

--- a/buildpacks/jvm/tests/integration/overlay.rs
+++ b/buildpacks/jvm/tests/integration/overlay.rs
@@ -1,0 +1,42 @@
+use crate::default_build_config;
+use libcnb_test::{assert_contains, TestRunner};
+use std::path::PathBuf;
+
+#[test]
+#[ignore = "integration test"]
+fn overlay() {
+    const ADDITIONAL_PATH: &str = "earth.txt";
+    const ADDITIONAL_CONTENTS: &str = "Un diminuto punto azul";
+
+    const CACERTS_PATH: &str = "lib/security/cacerts";
+    const CACERTS_CONTENTS: &str = "overwritten";
+
+    TestRunner::default().build(
+        default_build_config("test-apps/java-21-app").app_dir_preprocessor(|app_dir| {
+            let overlay_path = app_dir.join(".jdk-overlay");
+            std::fs::create_dir_all(&overlay_path).unwrap();
+            std::fs::write(overlay_path.join(ADDITIONAL_PATH), ADDITIONAL_CONTENTS).unwrap();
+
+            let cacerts_path = overlay_path.join(PathBuf::from(CACERTS_PATH));
+            std::fs::create_dir_all(cacerts_path.parent().unwrap()).unwrap();
+            std::fs::write(&cacerts_path, CACERTS_CONTENTS).unwrap();
+        }),
+        |context| {
+            // Validate that adding a new file works
+            assert_contains!(
+                context
+                    .run_shell_command(format!("cat $JAVA_HOME/{ADDITIONAL_PATH}"))
+                    .stdout,
+                ADDITIONAL_CONTENTS
+            );
+
+            // Validate that overwriting a file works
+            assert_contains!(
+                context
+                    .run_shell_command(format!("cat $JAVA_HOME/{CACERTS_PATH}"))
+                    .stdout,
+                CACERTS_CONTENTS
+            );
+        },
+    );
+}


### PR DESCRIPTION
The `heroku/jvm` buildpack used the wrong directory as the source for the JDK overlay. This PR fixes that and adds tests for the JDK overlay.

Fixes #738 