### PR TITLE
Add cargo-llvm-cov test coverage reports in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,31 @@ jobs:
       - name: Run unit tests
         run: cargo test --locked
 
+  # Currently a separate job since the #coverage(off) attribute requires nightly Rust. As soon as we can use llvm-cov
+  # without Rust nightly, we should merge this job with the regular unit tests.
+  unit-test-coverage:
+    name: Generate test coverage report
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install nightly Rust toolchain
+        run: rustup install nightly
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run unit tests and generate coverage report
+        run: cargo +nightly llvm-cov --locked --html
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: "llvm-cov-html-${{github.event.repository.name}}-${{github.sha}}"
+          path: "target/llvm-cov/html"
+          if-no-files-found: "error"
+
   integration-test:
     name: Integration Tests (${{ matrix.buildpack-directory }}, ${{matrix.builder}}, ${{matrix.arch}})
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-large' || 'pub-hk-ubuntu-24.04-large' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ edition = "2021"
 unreachable_pub = "warn"
 unsafe_code = "warn"
 unused_crate_dependencies = "warn"
+# Allows the usage of cfg(coverage_nightly).
+# cargo-llvm-cov enables that config when instrumenting our code, so we can enable
+# the experimental coverage_attribute feature.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/buildpacks/gradle/src/main.rs
+++ b/buildpacks/gradle/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use crate::config::GradleBuildpackConfig;
 use crate::detect::is_gradle_project_directory;
 use crate::errors::on_error_gradle_buildpack;

--- a/buildpacks/jvm-function-invoker/src/main.rs
+++ b/buildpacks/jvm-function-invoker/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use crate::common::project_toml_salesforce_type_is_function;
 use crate::error::{handle_buildpack_error, JvmFunctionInvokerBuildpackError};
 use crate::layers::bundle::handle_bundle;

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 mod constants;
 mod errors;
 mod layers;
@@ -88,6 +93,7 @@ impl Buildpack for OpenJdkBuildpack {
         DetectResultBuilder::pass().build_plan(build_plan).build()
     }
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let openjdk_artifact_requirement = read_system_properties(&context.app_dir)
             .map_err(OpenJdkBuildpackError::ReadSystemPropertiesError)

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use crate::errors::on_error_maven_buildpack;
 use crate::framework::DefaultAppProcessError;
 use crate::layer::maven::handle_maven_layer;

--- a/buildpacks/sbt/src/main.rs
+++ b/buildpacks/sbt/src/main.rs
@@ -1,3 +1,8 @@
+// cargo-llvm-cov sets the coverage_nightly attribute when instrumenting our code. In that case,
+// we enable https://doc.rust-lang.org/beta/unstable-book/language-features/coverage-attribute.html
+// to be able selectively opt out of coverage for functions/lines/modules.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 mod configuration;
 mod detect;
 mod errors;


### PR DESCRIPTION
This PR adds a new GHA job that uploads an HTML report of unit test code coverage to the GHA run. It's separated from the normal unit test runs by design as the coverage report requires nightly Rust. Should the coverage report fail to generate, all other jobs still run as usual. Failure to generate the report will not block PRs.

This setup uses https://github.com/taiki-e/cargo-llvm-cov to use [llvm-cov](https://llvm.org/docs/CommandGuide/llvm-cov.html) with Cargo. 

Buildpacks usually contain a lot of code that is not unit-testable as it shells out to other programs or is heavy on FS interactions. Code that is not unit-testable can be excluded by using an attribute like so:

```rust
#[cfg_attr(coverage_nightly, coverage(off))]
fn buildpack_code() {}
```

The final report will be appended to the GHA run as a ZIP file. See the artifact sections of this run for an example: https://github.com/heroku/buildpacks-jvm/actions/runs/12656240196

Closes [GUS-W-17560152](https://gus--c.vf.force.com/a07EE000027hTrKYAU)