### PR TITLE
[Stacked] Proof of concept bullet stream global functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,11 @@ jobs:
         # Runs only tests annotated with the `ignore` attribute (which in this repo, are the integration tests).
         run: cargo test --locked -- --ignored --test-threads 16
 
-  print-pack-getting-started-output:
-    runs-on: ${{ matrix.target == 'aarch64-unknown-linux-musl' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
+  print-guide:
+    runs-on: 'pub-hk-ubuntu-24.04-arm-medium'
     strategy:
       matrix:
-        target: ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
-        guide: ["heroku/java-getting-started", "heroku/gradle-getting-started", "heroku/scala-getting-started"]
+        guide: ["java-getting-started", "gradle-getting-started", "scala-getting-started"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -114,7 +113,7 @@ jobs:
       - name: Update Rust toolchain
         run: rustup update
       - name: Install Rust linux-musl target
-        run: rustup target add ${{ matrix.target }}
+        run: rustup target add aarch64-unknown-linux-musl
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.5
       - name: Install Pack CLI
@@ -126,31 +125,31 @@ jobs:
       - name: Clone getting started guide
         uses: actions/checkout@v4
         with:
-          repository: ${{ matrix.guide }}
+          repository: "heroku/${{ matrix.guide }}"
           path: tmp/guide
       - name: Install libcnb-cargo for `cargo libcnb package` command
         run: cargo install libcnb-cargo
       - name: Compile buildpack
-        run: cargo libcnb package --target ${{ matrix.target }}
+        run: cargo libcnb package --target aarch64-unknown-linux-musl
       - name: "PRINT: Getting started guide output"
         run: |
           set -euo pipefail
 
           PACK_CMD="pack build my-image --force-color --builder heroku/builder:24 --trust-extra-buildpacks --path tmp/guide --pull-policy never "
           case "${{ matrix.guide }}" in
-            "heroku/java-getting-started")
-              PACK_CMD+=" --buildpack packaged/${{ matrix.target }}/debug/heroku_jvm "
-              PACK_CMD+=" --buildpack packaged/${{ matrix.target }}/debug/heroku_java "
-              PACK_CMD+=" --buildpack packaged/${{ matrix.target }}/debug/heroku_maven "
+            "java-getting-started")
+              PACK_CMD+=" --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_jvm "
+              PACK_CMD+=" --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_java "
+              PACK_CMD+=" --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_maven "
               ;;
-            "heroku/gradle-getting-started")
-              PACK_CMD+=" --buildpack packaged/${{ matrix.target }}/debug/heroku_jvm "
-              PACK_CMD+=" --buildpack packaged/${{ matrix.target }}/debug/heroku_gradle "
+            "gradle-getting-started")
+              PACK_CMD+=" --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_jvm "
+              PACK_CMD+=" --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_gradle "
               ;;
-            "heroku/scala-getting-started")
-              PACK_CMD+=" --buildpack packaged/${{ matrix.target }}/debug/heroku_jvm "
-              PACK_CMD+=" --buildpack packaged/${{ matrix.target }}/debug/heroku_sbt "
-              PACK_CMD+=" --buildpack packaged/${{ matrix.target }}/debug/heroku_scala "
+            "scala-getting-started")
+              PACK_CMD+=" --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_jvm "
+              PACK_CMD+=" --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_sbt "
+              PACK_CMD+=" --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_scala "
               ;;
             *)
               echo "Unknown guide: ${{ matrix.guide }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,6 @@ dependencies = [
  "fun_run",
  "indoc",
  "java-properties",
- "libherokubuildpack",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,11 +375,10 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fun_run"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1060b826a0883f31399a72e983a55ad0b38830429a5d1dff3719aac9782415"
+checksum = "febb7528c7984a6a26642b0332198fd3c43e5aba70c025f83e624c0d20a23729"
 dependencies = [
- "lazy_static",
  "regex",
 ]
 
@@ -423,6 +422,7 @@ version = "0.0.0"
 dependencies = [
  "buildpacks-jvm-shared",
  "buildpacks-jvm-shared-test",
+ "fun_run",
  "indoc",
  "libcnb",
  "libcnb-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "libherokubuildpack",
  "nom",
  "serde",
+ "tempfile",
 ]
 
 [[package]]
@@ -1135,12 +1136,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,6 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45070d23cda8614758579eddae211a6267e86bcef8ab75a1cd239eac45a6778d"
 dependencies = [
- "crossbeam-utils",
  "flate2",
  "hex",
  "libcnb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,8 @@ dependencies = [
 name = "buildpacks-jvm-shared"
 version = "0.0.0"
 dependencies = [
+ "bullet_stream",
+ "fun_run",
  "indoc",
  "java-properties",
  "libherokubuildpack",
@@ -137,6 +139,12 @@ dependencies = [
  "libcnb-test",
  "ureq",
 ]
+
+[[package]]
+name = "bullet_stream"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921deeb7be278ed3819b35191dcb33784acfaed6ce11f75fb658b4e94627af22"
 
 [[package]]
 name = "camino"
@@ -365,6 +373,16 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fun_run"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1060b826a0883f31399a72e983a55ad0b38830429a5d1dff3719aac9782415"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "generic-array"

--- a/buildpacks/gradle/Cargo.toml
+++ b/buildpacks/gradle/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 buildpacks-jvm-shared.workspace = true
 indoc = "2"
 libcnb = "=0.26.0"
-libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["command", "error"] }
+libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["error"] }
 nom = "7"
 serde = { version = "1", features = ["derive"] }
 tempfile = "3.15.0"

--- a/buildpacks/gradle/Cargo.toml
+++ b/buildpacks/gradle/Cargo.toml
@@ -14,6 +14,7 @@ libherokubuildpack = { version = "=0.26.0", default-features = false, features =
 nom = "7"
 serde = { version = "1", features = ["derive"] }
 tempfile = "3.15.0"
+fun_run = "0.4.0"
 
 [dev-dependencies]
 buildpacks-jvm-shared-test.workspace = true

--- a/buildpacks/gradle/Cargo.toml
+++ b/buildpacks/gradle/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 buildpacks-jvm-shared.workspace = true
 indoc = "2"
 libcnb = "=0.26.0"
-libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["command", "error", "log"] }
+libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["command", "error"] }
 nom = "7"
 serde = { version = "1", features = ["derive"] }
 tempfile = "3.15.0"

--- a/buildpacks/gradle/Cargo.toml
+++ b/buildpacks/gradle/Cargo.toml
@@ -13,6 +13,7 @@ libcnb = "=0.26.0"
 libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["command", "error", "log"] }
 nom = "7"
 serde = { version = "1", features = ["derive"] }
+tempfile = "3.15.0"
 
 [dev-dependencies]
 buildpacks-jvm-shared-test.workspace = true

--- a/buildpacks/gradle/src/errors.rs
+++ b/buildpacks/gradle/src/errors.rs
@@ -1,12 +1,7 @@
-use std::process::Output;
-
 use crate::GradleBuildpackError;
 use buildpacks_jvm_shared::{
-    log::{
-        log_build_tool_io_error, log_build_tool_unexpected_exit_code_error,
-        log_please_try_again_error,
-    },
-    output::{print_error, CmdError},
+    log::{log_build_tool_command_error, log_please_try_again_error},
+    output::print_error,
 };
 use indoc::indoc;
 
@@ -28,16 +23,9 @@ pub(crate) fn on_error_gradle_buildpack(error: GradleBuildpackError) {
                 "},
             );
         }
-        GradleBuildpackError::GradleBuildFailedCommand(error) => match error {
-            CmdError::SystemError(_, error) => log_build_tool_io_error("Gradle", error),
-            CmdError::NonZeroExitNotStreamed(named_output)
-            | CmdError::NonZeroExitAlreadyStreamed(named_output) => {
-                log_build_tool_unexpected_exit_code_error(
-                    "Gradle",
-                    Into::<Output>::into(named_output.clone()).status,
-                );
-            }
-        },
+        GradleBuildpackError::GradleBuildFailedCommand(error) => {
+            log_build_tool_command_error("Gradle", &error);
+        }
         GradleBuildpackError::GetTasksError(error) => log_please_try_again_error(
             "Failed to get Gradle tasks",
             "Failed to get Gradle tasks",

--- a/buildpacks/gradle/src/errors.rs
+++ b/buildpacks/gradle/src/errors.rs
@@ -6,16 +6,15 @@ use buildpacks_jvm_shared::{
         log_build_tool_io_error, log_build_tool_unexpected_exit_code_error,
         log_please_try_again_error,
     },
-    output::CmdError,
+    output::{print_error, CmdError},
 };
 use indoc::indoc;
-use libherokubuildpack::log::log_error;
 
 #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
 pub(crate) fn on_error_gradle_buildpack(error: GradleBuildpackError) {
     match error {
         GradleBuildpackError::GradleWrapperNotFound => {
-            log_error(
+            print_error(
                 "Missing Gradle Wrapper",
                 indoc! {"
                     This buildpack leverages Gradle Wrapper to install the correct Gradle version to build your application.
@@ -71,7 +70,7 @@ pub(crate) fn on_error_gradle_buildpack(error: GradleBuildpackError) {
             "The Gradle daemon for this build could not be started.",
             error,
         ),
-        GradleBuildpackError::BuildTaskUnknown => log_error(
+        GradleBuildpackError::BuildTaskUnknown => print_error(
             "Failed to determine build task",
             indoc! {"
                 It looks like your project does not contain a 'stage' task, which Heroku needs in order

--- a/buildpacks/gradle/src/gradle_command/daemon.rs
+++ b/buildpacks/gradle/src/gradle_command/daemon.rs
@@ -2,33 +2,54 @@ use crate::gradle_command::GradleCommandError;
 use crate::GRADLE_TASK_NAME_HEROKU_START_DAEMON;
 use buildpacks_jvm_shared::output::{self, CmdError};
 use libcnb::Env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tempfile::NamedTempFile;
 
-pub(crate) struct GradleDaemonLog {
+pub(crate) struct GradleDaemon {
+    name: String,
     file: NamedTempFile,
+    executable_path: PathBuf,
+}
+
+impl GradleDaemon {
+    pub(crate) fn stop(self, gradle_env: &Env) -> Result<(), GradleCommandError<()>> {
+        let file = self.file.reopen().map_err(GradleCommandError::Io)?;
+        let _ = Command::new(self.executable_path)
+            .args(["-q", "--stop"])
+            .envs(gradle_env)
+            .stdout(Stdio::from(
+                file.try_clone().map_err(GradleCommandError::Io)?,
+            ))
+            .stderr(Stdio::from(file))
+            .spawn()
+            .and_then(|mut child| child.wait())
+            .map_err(GradleCommandError::Io)?;
+
+        Ok(())
+    }
 }
 
 pub(crate) fn start(
     gradle_wrapper_executable_path: &Path,
     gradle_env: &Env,
-) -> Result<GradleDaemonLog, GradleCommandError<()>> {
-    let log = GradleDaemonLog {
+) -> Result<GradleDaemon, GradleCommandError<()>> {
+    let daemon = GradleDaemon {
+        name: GRADLE_TASK_NAME_HEROKU_START_DAEMON.to_string(),
+        executable_path: gradle_wrapper_executable_path.to_path_buf(),
         file: tempfile::NamedTempFile::new().map_err(GradleCommandError::Io)?,
     };
-    std::fs::write(&log.file, "").map_err(GradleCommandError::Io)?;
-    let mut command = Command::new(gradle_wrapper_executable_path);
+    std::fs::write(&daemon.file, "").map_err(GradleCommandError::Io)?;
+    let mut command = Command::new(&daemon.executable_path);
     command
         .args([
             // Fixes an issue when running under Apple Rosetta emulation
             "-Djdk.lang.Process.launchMechanism=vfork",
             "--daemon",
-            GRADLE_TASK_NAME_HEROKU_START_DAEMON,
+            &daemon.name,
         ])
         .envs(gradle_env);
-    let file = log.file.reopen().map_err(GradleCommandError::Io)?;
-
+    let file = daemon.file.reopen().map_err(GradleCommandError::Io)?;
     command.stdout(Stdio::from(
         file.try_clone().map_err(GradleCommandError::Io)?,
     ));
@@ -45,19 +66,6 @@ pub(crate) fn start(
             }
         }
     })?;
-    Ok(log)
-}
 
-pub(crate) fn stop(
-    gradle_wrapper_executable_path: &Path,
-    gradle_env: &Env,
-) -> Result<(), GradleCommandError<()>> {
-    Command::new(gradle_wrapper_executable_path)
-        .args(["-q", "--stop"])
-        .envs(gradle_env)
-        .spawn()
-        .and_then(|mut child| child.wait())
-        .map_err(GradleCommandError::Io)?;
-
-    Ok(())
+    Ok(daemon)
 }

--- a/buildpacks/gradle/src/gradle_command/daemon.rs
+++ b/buildpacks/gradle/src/gradle_command/daemon.rs
@@ -1,35 +1,51 @@
 use crate::gradle_command::GradleCommandError;
 use crate::GRADLE_TASK_NAME_HEROKU_START_DAEMON;
+use buildpacks_jvm_shared::output::{self, CmdError};
 use libcnb::Env;
-use libherokubuildpack::command::CommandExt;
-use std::io::{stderr, stdout};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use tempfile::NamedTempFile;
+
+pub(crate) struct GradleDaemonLog {
+    file: NamedTempFile,
+}
 
 pub(crate) fn start(
     gradle_wrapper_executable_path: &Path,
     gradle_env: &Env,
-) -> Result<(), GradleCommandError<()>> {
-    let output = Command::new(gradle_wrapper_executable_path)
+) -> Result<GradleDaemonLog, GradleCommandError<()>> {
+    let log = GradleDaemonLog {
+        file: tempfile::NamedTempFile::new().map_err(GradleCommandError::Io)?,
+    };
+    std::fs::write(&log.file, "").map_err(GradleCommandError::Io)?;
+    let mut command = Command::new(gradle_wrapper_executable_path);
+    command
         .args([
             // Fixes an issue when running under Apple Rosetta emulation
             "-Djdk.lang.Process.launchMechanism=vfork",
             "--daemon",
             GRADLE_TASK_NAME_HEROKU_START_DAEMON,
         ])
-        .envs(gradle_env)
-        .output_and_write_streams(stdout(), stderr())
-        .map_err(GradleCommandError::Io)?;
+        .envs(gradle_env);
+    let file = log.file.reopen().map_err(GradleCommandError::Io)?;
 
-    if output.status.success() {
-        Ok(())
-    } else {
-        Err(GradleCommandError::UnexpectedExitStatus {
-            status: output.status,
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-        })
-    }
+    command.stdout(Stdio::from(
+        file.try_clone().map_err(GradleCommandError::Io)?,
+    ));
+    command.stderr(Stdio::from(file));
+
+    let _ = output::run_command(command, true).map_err(|error| match error {
+        CmdError::SystemError(_, error) => GradleCommandError::Io(error),
+        CmdError::NonZeroExitNotStreamed(named_output)
+        | CmdError::NonZeroExitAlreadyStreamed(named_output) => {
+            GradleCommandError::UnexpectedExitStatus {
+                status: *named_output.status(),
+                stdout: named_output.stdout_lossy(),
+                stderr: named_output.stderr_lossy(),
+            }
+        }
+    })?;
+    Ok(log)
 }
 
 pub(crate) fn stop(

--- a/buildpacks/gradle/src/gradle_command/mod.rs
+++ b/buildpacks/gradle/src/gradle_command/mod.rs
@@ -3,7 +3,6 @@ mod dependency_report;
 mod tasks;
 
 pub(crate) use daemon::start as start_daemon;
-pub(crate) use daemon::stop as stop_daemon;
 pub(crate) use dependency_report::{dependency_report, GradleDependencyReport};
 pub(crate) use tasks::tasks;
 

--- a/buildpacks/gradle/src/main.rs
+++ b/buildpacks/gradle/src/main.rs
@@ -103,7 +103,6 @@ impl Buildpack for GradleBuildpack {
         })?;
 
         let dependency_report = track_timing_subsection("Querying dependency report", || {
-            print_subsection("Querying dependency report");
             gradle_command::dependency_report(&context.app_dir, &gradle_env)
                 .map_err(GradleBuildpackError::GetDependencyReportError)
         })?;

--- a/buildpacks/gradle/src/main.rs
+++ b/buildpacks/gradle/src/main.rs
@@ -130,10 +130,10 @@ impl Buildpack for GradleBuildpack {
         // Explicitly ignoring the result. If the daemon cannot be stopped, that is not a build
         // failure, nor can we recover from it in any way.
 
-        output::track_timing_subsection("Stopping Gradle daemon", || {
-            gradle_daemon.stop(&gradle_env)
-        })
-        .map_err(GradleBuildpackError::StartGradleDaemonError)?;
+        print_section("Stopping Gradle daemon");
+        gradle_daemon
+            .stop(&gradle_env)
+            .map_err(GradleBuildpackError::StartGradleDaemonError)?;
 
         let process = default_app_process(&dependency_report, &context.app_dir)
             .map_err(GradleBuildpackError::CannotDetermineDefaultAppProcess)?;

--- a/buildpacks/jvm/Cargo.toml
+++ b/buildpacks/jvm/Cargo.toml
@@ -11,7 +11,7 @@ buildpacks-jvm-shared.workspace = true
 fs_extra = "1"
 indoc = "2"
 libcnb = "=0.26.0"
-libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["digest", "download", "error", "inventory", "inventory-sha2", "log", "tar"] }
+libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["digest", "download", "error", "inventory", "inventory-sha2", "tar"] }
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"
 url = "2"

--- a/buildpacks/jvm/src/errors.rs
+++ b/buildpacks/jvm/src/errors.rs
@@ -4,9 +4,9 @@ use crate::openjdk_artifact::{
 use crate::version_resolver::VersionResolveError;
 use crate::OpenJdkBuildpackError;
 use buildpacks_jvm_shared::log::{log_please_try_again, log_please_try_again_error};
+use buildpacks_jvm_shared::output::print_error;
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
-use libherokubuildpack::log::log_error;
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
@@ -18,7 +18,7 @@ pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
         ),
         OpenJdkBuildpackError::ReadSystemPropertiesError(
             ReadSystemPropertiesError::ParseError(error),
-        ) => log_error(
+        ) => print_error(
             "Invalid system.properties file",
             formatdoc! {"
                 Could not parse your application's system.properties file. Please ensure that your
@@ -71,14 +71,14 @@ pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
         ),
         OpenJdkBuildpackError::UnsupportedOpenJdkVersion(artifact_requirement) => {
             match artifact_requirement.version {
-                HerokuOpenJdkVersionRequirement::Major(major_version) => log_error(
+                HerokuOpenJdkVersionRequirement::Major(major_version) => print_error(
                     "Unsupported OpenJDK version",
                     formatdoc! {"
                         The OpenJDK major version {major_version} you specified in your system.properties file is not supported.
                         Please specify a supported major version in your system.properties file.
                     ", major_version = major_version },
                 ),
-                HerokuOpenJdkVersionRequirement::Specific(version) => log_error(
+                HerokuOpenJdkVersionRequirement::Specific(version) => print_error(
                     "Unsupported OpenJDK version",
                     formatdoc! {"
                         The OpenJDK version {version} you specified in your system.properties file is not supported.
@@ -90,7 +90,7 @@ pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
                 )
             }
         },
-        OpenJdkBuildpackError::ParseInventoryError(error) => log_error(
+        OpenJdkBuildpackError::ParseInventoryError(error) => print_error(
             "Invalid Inventory File",
             formatdoc! {"
                 The inventory of OpenJDK distributions could not be parsed. This error should
@@ -111,7 +111,7 @@ pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
                 Actual: {actual}
             ", expected = hex::encode(expected), actual = hex::encode(actual) }
         ),
-        OpenJdkBuildpackError::ResolveVersionError(VersionResolveError::OpenJdkArtifactRequirementParseError(OpenJdkArtifactRequirementParseError::UnknownDistribution(distribution))) => log_error(
+        OpenJdkBuildpackError::ResolveVersionError(VersionResolveError::OpenJdkArtifactRequirementParseError(OpenJdkArtifactRequirementParseError::UnknownDistribution(distribution))) => print_error(
             format!("Unsupported distribution: {distribution}"),
             formatdoc! {"
                     Please check your system.properties file to ensure the java.runtime.version
@@ -124,7 +124,7 @@ pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
                     Heroku
             "}),
         OpenJdkBuildpackError::ResolveVersionError(VersionResolveError::OpenJdkArtifactRequirementParseError(OpenJdkArtifactRequirementParseError::OpenJdkVersionParseError(_))) => {
-            log_error(
+            print_error(
                 "Invalid OpenJDK version selector",
                 formatdoc! {"
             The OpenJDK version selector you specified in your system.properties file is invalid.
@@ -135,7 +135,7 @@ pub(crate) fn on_error_jvm_buildpack(error: OpenJdkBuildpackError) {
             );
         }
         OpenJdkBuildpackError::ResolveVersionError(VersionResolveError::ReadSystemPropertiesError(error)) => {
-            log_error(
+            print_error(
                 "Invalid system.properties file",
                 formatdoc! {"
             The contents of your system.properties file cannot be parsed. Please use a valid

--- a/buildpacks/jvm/src/main.rs
+++ b/buildpacks/jvm/src/main.rs
@@ -40,6 +40,7 @@ use libherokubuildpack::inventory::artifact::{Arch, Os};
 use libherokubuildpack::inventory::{Inventory, ParseInventoryError};
 use sha2::Sha256;
 use std::env::consts;
+use std::time::Instant;
 use url as _; // Used by exec.d binary
 
 struct OpenJdkBuildpack;
@@ -92,6 +93,7 @@ impl Buildpack for OpenJdkBuildpack {
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        let build_timer = Instant::now();
         output::print_buildpack_name("Heroku OpenJDK Buildpack");
 
         let resolved_version = resolve_version(&context.app_dir)
@@ -181,7 +183,7 @@ impl Buildpack for OpenJdkBuildpack {
 
         handle_openjdk_layer(&context, openjdk_artifact)?;
         handle_runtime_layer(&context)?;
-
+        output::print_all_done(build_timer);
         BuildResultBuilder::new().build()
     }
 

--- a/buildpacks/jvm/tests/integration/versions.rs
+++ b/buildpacks/jvm/tests/integration/versions.rs
@@ -16,21 +16,21 @@ fn openjdk_default() {
         ]),
         |context| {
             assert_contains!(
-                context.pack_stderr,
-                &formatdoc! {"
+                trim_end_of_lines(&context.pack_stderr),
+                &trim_end_of_lines(&formatdoc! {"
                     ! WARNING: No OpenJDK version specified
-                    ! 
+                    !
                     ! Your application does not explicitly specify an OpenJDK version. The latest
                     ! long-term support (LTS) version will be installed. This currently is OpenJDK 21.
-                    ! 
+                    !
                     ! This default version will change when a new LTS version is released. Your
                     ! application might fail to build with the new version. We recommend explicitly
                     ! setting the required OpenJDK version for your application.
-                    ! 
+                    !
                     ! To set the OpenJDK version, add or edit the system.properties file in the root
                     ! directory of your application to contain:
-                    ! 
-                    ! java.runtime.version = 21"});
+                    !
+                    ! java.runtime.version = 21"}));
 
             assert_contains!(
                 context.run_shell_command("java -version").stderr,
@@ -38,6 +38,14 @@ fn openjdk_default() {
             );
         },
     );
+}
+
+fn trim_end_of_lines(input: &str) -> String {
+    input
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<&str>>()
+        .join("\n")
 }
 
 #[test]

--- a/buildpacks/maven/src/errors.rs
+++ b/buildpacks/maven/src/errors.rs
@@ -1,9 +1,8 @@
 use crate::{MavenBuildpackError, SettingsError};
 use buildpacks_jvm_shared::log::{
-    log_build_tool_io_error, log_build_tool_unexpected_exit_code_error, log_please_try_again,
-    log_please_try_again_error,
+    log_build_tool_command_error, log_please_try_again, log_please_try_again_error,
 };
-use buildpacks_jvm_shared::output::{print_error, CmdError};
+use buildpacks_jvm_shared::output::print_error;
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
 
@@ -82,13 +81,7 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
             "},
             error
         ),
-        MavenBuildpackError::MavenFailedCommand(error) => {
-            match error {
-                CmdError::SystemError(_, error) => log_build_tool_io_error("Maven", error),
-                CmdError::NonZeroExitNotStreamed(named_output) |
-                CmdError::NonZeroExitAlreadyStreamed(named_output) => log_build_tool_unexpected_exit_code_error("Maven",*named_output.status()),
-            }
-        }
+        MavenBuildpackError::MavenFailedCommand(error) => log_build_tool_command_error("Maven", &error),
         MavenBuildpackError::CannotSplitMavenCustomOpts(error) => print_error(
             "Invalid MAVEN_CUSTOM_OPTS",
             formatdoc! {"

--- a/buildpacks/maven/src/errors.rs
+++ b/buildpacks/maven/src/errors.rs
@@ -87,7 +87,7 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
             match error {
                 CmdError::SystemError(_, error) => log_build_tool_io_error("Maven", error),
                 CmdError::NonZeroExitNotStreamed(named_output) |
-                CmdError::NonZeroExitAlreadyStreamed(named_output) => log_build_tool_unexpected_exit_code_error("Maven",named_output.status().clone()),
+                CmdError::NonZeroExitAlreadyStreamed(named_output) => log_build_tool_unexpected_exit_code_error("Maven",*named_output.status()),
             }
         }
         MavenBuildpackError::CannotSplitMavenCustomOpts(error) => log_error(

--- a/buildpacks/maven/src/errors.rs
+++ b/buildpacks/maven/src/errors.rs
@@ -3,10 +3,9 @@ use buildpacks_jvm_shared::log::{
     log_build_tool_io_error, log_build_tool_unexpected_exit_code_error, log_please_try_again,
     log_please_try_again_error,
 };
-use buildpacks_jvm_shared::output::CmdError;
+use buildpacks_jvm_shared::output::{print_error, CmdError};
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
-use libherokubuildpack::log::log_error;
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
@@ -41,14 +40,14 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
             "While trying to determine a default process based on the used application framework, an unexpected error occurred.",
             error,
         ),
-        MavenBuildpackError::UnsupportedMavenVersion(version) => log_error(
+        MavenBuildpackError::UnsupportedMavenVersion(version) => print_error(
             "Unsupported Maven version",
             formatdoc! {"
                 You have defined an unsupported Maven version ({version}) in the system.properties file.
             ", version = version },
         ),
         MavenBuildpackError::SettingsError(SettingsError::InvalidMavenSettingsPath(path)) => {
-            log_error(
+            print_error(
                 "Cannot find custom settings.xml file",
                 formatdoc! {"
                     You have set MAVEN_SETTINGS_PATH to \"{path}\". We could not find that file in your app.
@@ -56,7 +55,7 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
                 ", path = path.to_string_lossy() },
             );
         },
-        MavenBuildpackError::SettingsError(SettingsError::DownloadError(url, error)) => log_error(
+        MavenBuildpackError::SettingsError(SettingsError::DownloadError(url, error)) => print_error(
             "Download of settings.xml failed",
             formatdoc! {"
                 You have set MAVEN_SETTINGS_URL to \"{url}\". We tried to download the file at this
@@ -90,7 +89,7 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
                 CmdError::NonZeroExitAlreadyStreamed(named_output) => log_build_tool_unexpected_exit_code_error("Maven",*named_output.status()),
             }
         }
-        MavenBuildpackError::CannotSplitMavenCustomOpts(error) => log_error(
+        MavenBuildpackError::CannotSplitMavenCustomOpts(error) => print_error(
             "Invalid MAVEN_CUSTOM_OPTS",
             formatdoc! {"
                 Could not split the value of the MAVEN_CUSTOM_OPTS environment variable into separate
@@ -99,7 +98,7 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
                 Details: {error}
             ", error = error },
         ),
-        MavenBuildpackError::CannotSplitMavenCustomGoals(error) => log_error(
+        MavenBuildpackError::CannotSplitMavenCustomGoals(error) => print_error(
             "Invalid MAVEN_CUSTOM_GOALS",
             formatdoc! {"
                 Could not split the value of the MAVEN_CUSTOM_GOALS environment variable into separate
@@ -110,7 +109,7 @@ pub(crate) fn on_error_maven_buildpack(error: MavenBuildpackError) {
         ),
         MavenBuildpackError::DetermineModeError(
             ReadSystemPropertiesError::ParseError(error),
-        ) => log_error(
+        ) => print_error(
             "Invalid system.properties file",
             formatdoc! {"
                 Could not parse your application's system.properties file. Please ensure that your

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -210,19 +210,9 @@ impl Buildpack for MavenBuildpack {
         let internal_maven_options = vec![String::from("-B")];
 
         output::print_section("Running Maven build");
-        output::print_subsection(BuildpackOutputText::new(vec![
-            BuildpackOutputTextSection::regular("Running "),
-            BuildpackOutputTextSection::command(format!(
-                "{} {} {}",
-                mvn_executable.to_string_lossy(),
-                shell_words::join(&maven_options),
-                shell_words::join(&maven_goals)
-            )),
-        ]));
 
-        output::track_timing(|| {
+        {
             let mut command = Command::new(&mvn_executable);
-
             command
                 .current_dir(&context.app_dir)
                 .args(
@@ -238,8 +228,8 @@ impl Buildpack for MavenBuildpack {
                 false,
                 MavenBuildpackError::MavenBuildIoError,
                 |output| MavenBuildpackError::MavenBuildUnexpectedExitCode(output.status),
-            )
-        })?;
+            )?
+        };
 
         output::print_section(BuildpackOutputText::new(vec![
             BuildpackOutputTextSection::regular("Running "),

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -227,37 +227,25 @@ impl Buildpack for MavenBuildpack {
 
             output::run_command(command, false).map_err(MavenBuildpackError::MavenFailedCommand)?
         };
-        output::track_timing_subsection(
-            BuildpackOutputText::new(vec![
-                BuildpackOutputTextSection::regular("Running "),
-                BuildpackOutputTextSection::value(format!(
-                    "{} dependency:list",
-                    mvn_executable.to_string_lossy()
-                )),
-                BuildpackOutputTextSection::regular(" quietly"),
-            ]),
-            || {
-                let mut command = Command::new(&mvn_executable);
 
-                command
-                    .current_dir(&context.app_dir)
-                    .args(
-                        maven_options.iter().chain(&internal_maven_options).chain(
-                            [
-                                format!(
-                                    "-DoutputFile={}",
-                                    app_dependency_list_path(&context.app_dir).to_string_lossy()
-                                ),
-                                String::from("dependency:list"),
-                            ]
-                            .iter(),
+        let mut command = Command::new(&mvn_executable);
+        command
+            .current_dir(&context.app_dir)
+            .args(
+                maven_options.iter().chain(&internal_maven_options).chain(
+                    [
+                        format!(
+                            "-DoutputFile={}",
+                            app_dependency_list_path(&context.app_dir).to_string_lossy()
                         ),
-                    )
-                    .envs(&mvn_env);
+                        String::from("dependency:list"),
+                    ]
+                    .iter(),
+                ),
+            )
+            .envs(&mvn_env);
 
-                output::run_command(command, true).map_err(MavenBuildpackError::MavenFailedCommand)
-            },
-        )?;
+        output::run_command(command, true).map_err(MavenBuildpackError::MavenFailedCommand)?;
 
         let mut build_result_builder = BuildResultBuilder::new();
 

--- a/buildpacks/maven/src/main.rs
+++ b/buildpacks/maven/src/main.rs
@@ -20,6 +20,7 @@ use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
+use std::time::Instant;
 
 use buildpacks_jvm_shared::output;
 use buildpacks_jvm_shared::output::{BuildpackOutputText, BuildpackOutputTextSection};
@@ -102,6 +103,7 @@ impl Buildpack for MavenBuildpack {
 
     #[allow(clippy::too_many_lines)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        let build_timer = Instant::now();
         output::print_buildpack_name("Heroku Maven Buildpack");
 
         let mut current_or_platform_env = Env::from_current();
@@ -277,6 +279,7 @@ impl Buildpack for MavenBuildpack {
                 build_result_builder.launch(LaunchBuilder::new().process(process).build());
         }
 
+        output::print_all_done(build_timer);
         build_result_builder.build()
     }
 

--- a/buildpacks/maven/src/warnings.rs
+++ b/buildpacks/maven/src/warnings.rs
@@ -1,8 +1,8 @@
+use buildpacks_jvm_shared::output::print_warning;
 use indoc::formatdoc;
-use libherokubuildpack::log::log_warning;
 
 pub(crate) fn log_unused_maven_wrapper_warning(version: &str) {
-    log_warning(
+    print_warning(
         "Unused Maven wrapper",
         formatdoc! {"
             Your application contains Maven wrapper, but a Maven version was also specified in system.properties.
@@ -13,7 +13,7 @@ pub(crate) fn log_unused_maven_wrapper_warning(version: &str) {
 }
 
 pub(crate) fn log_default_maven_version_warning(version: &str) {
-    log_warning(
+    print_warning(
         "Using default version",
         formatdoc! {"
             Your application does not explicitly specify which Maven version should be used to build your application.

--- a/buildpacks/maven/tests/integration/caching.rs
+++ b/buildpacks/maven/tests/integration/caching.rs
@@ -7,12 +7,12 @@ fn cache_dependencies_between_builds() {
     TestRunner::default().build(
         default_build_config("test-apps/simple-http-service"),
         |context| {
-            assert_contains!(context.pack_stdout, "Downloading from central");
+            assert_contains!(context.pack_stderr, "Downloading from central");
 
             context.rebuild(
                 default_build_config("test-apps/simple-http-service"),
                 |context| {
-                    assert_not_contains!(context.pack_stdout, "Downloading from central");
+                    assert_not_contains!(context.pack_stderr, "Downloading from central");
                 },
             );
         },

--- a/buildpacks/maven/tests/integration/customization.rs
+++ b/buildpacks/maven/tests/integration/customization.rs
@@ -7,7 +7,7 @@ use libcnb_test::{assert_contains, TestRunner};
 fn maven_custom_goals() {
     TestRunner::default().build(default_build_config("test-apps/simple-http-service").env("MAVEN_CUSTOM_GOALS", "site"), |context| {
         // Assert only the goals in MAVEN_CUSTOM_GOALS are executed
-        assert_contains!(context.pack_stderr, "./mvnw -DskipTests site");
+        assert_contains!(context.pack_stderr, "./mvnw -DskipTests -B site");
         assert_contains!(context.pack_stderr,"[INFO] --- maven-site-plugin:3.7.1:site (default-site) @ simple-http-service ---");
 
         // The dependency list is implemented by using the dependency:list goal. We need to

--- a/buildpacks/maven/tests/integration/customization.rs
+++ b/buildpacks/maven/tests/integration/customization.rs
@@ -7,8 +7,8 @@ use libcnb_test::{assert_contains, TestRunner};
 fn maven_custom_goals() {
     TestRunner::default().build(default_build_config("test-apps/simple-http-service").env("MAVEN_CUSTOM_GOALS", "site"), |context| {
         // Assert only the goals in MAVEN_CUSTOM_GOALS are executed
-        assert_contains!(context.pack_stdout, "./mvnw -DskipTests site");
-        assert_contains!(context.pack_stdout,"[INFO] --- maven-site-plugin:3.7.1:site (default-site) @ simple-http-service ---");
+        assert_contains!(context.pack_stderr, "./mvnw -DskipTests site");
+        assert_contains!(context.pack_stderr,"[INFO] --- maven-site-plugin:3.7.1:site (default-site) @ simple-http-service ---");
 
         // The dependency list is implemented by using the dependency:list goal. We need to
         // assert it won't be overwritten by the user's choice of goals.
@@ -46,13 +46,13 @@ fn maven_custom_opts() {
         default_build_config("test-apps/simple-http-service").env("MAVEN_CUSTOM_OPTS", "-X"),
         |context| {
             // Assert only the options in MAVEN_CUSTOM_GOALS are used
-            assert_contains!(context.pack_stdout, "./mvnw -X clean install");
-            assert_contains!(context.pack_stdout, "[DEBUG] -- end configuration --");
+            assert_contains!(context.pack_stderr, "./mvnw -X clean install");
+            assert_contains!(context.pack_stderr, "[DEBUG] -- end configuration --");
 
             // -DskipTests is part of the default Maven options. We expect it to be overridden by MAVEN_CUSTOM_OPTS and
             // therefore expect Maven to run tests.
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 "[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0"
             );
         },

--- a/buildpacks/maven/tests/integration/customization.rs
+++ b/buildpacks/maven/tests/integration/customization.rs
@@ -46,7 +46,7 @@ fn maven_custom_opts() {
         default_build_config("test-apps/simple-http-service").env("MAVEN_CUSTOM_OPTS", "-X"),
         |context| {
             // Assert only the options in MAVEN_CUSTOM_GOALS are used
-            assert_contains!(context.pack_stderr, "./mvnw -X clean install");
+            assert_contains!(context.pack_stderr, "./mvnw -X -B clean install");
             assert_contains!(context.pack_stderr, "[DEBUG] -- end configuration --");
 
             // -DskipTests is part of the default Maven options. We expect it to be overridden by MAVEN_CUSTOM_OPTS and

--- a/buildpacks/maven/tests/integration/misc.rs
+++ b/buildpacks/maven/tests/integration/misc.rs
@@ -14,7 +14,7 @@ fn mvnw_executable_bit() {
         |context| {
             // Assert the build completed successfully, even with a missing executable bit on
             // the Maven Wrapper executable.
-            assert_contains!(context.pack_stdout, "Successfully built image");
+            assert_contains!(context.pack_stderr, "Successfully built image");
         },
     );
 }
@@ -104,10 +104,10 @@ fn no_internal_maven_options_logging() {
     TestRunner::default().build(
         default_build_config("test-apps/simple-http-service"),
         |context| {
-            assert_not_contains!(context.pack_stdout, "-Dmaven.repo.local=");
-            assert_not_contains!(context.pack_stdout, "-Duser.home=");
+            assert_not_contains!(context.pack_stderr, "-Dmaven.repo.local=");
+            assert_not_contains!(context.pack_stderr, "-Duser.home=");
             assert_not_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 "-DoutputFile=target/mvn-dependency-list.log"
             );
         },
@@ -118,7 +118,7 @@ fn no_internal_maven_options_logging() {
 #[ignore = "integration test"]
 fn descriptive_error_message_on_failed_build() {
     TestRunner::default().build(default_build_config("test-apps/app-with-compile-error").expected_pack_result(PackResult::Failure), |context| {
-            assert_contains!(context.pack_stdout, "[INFO] BUILD FAILURE");
+            assert_contains!(context.pack_stderr, "[INFO] BUILD FAILURE");
 
             assert_contains!(
                 context.pack_stderr,

--- a/buildpacks/maven/tests/integration/misc.rs
+++ b/buildpacks/maven/tests/integration/misc.rs
@@ -14,7 +14,7 @@ fn mvnw_executable_bit() {
         |context| {
             // Assert the build completed successfully, even with a missing executable bit on
             // the Maven Wrapper executable.
-            assert_contains!(context.pack_stderr, "Successfully built image");
+            assert_contains!(context.pack_stdout, "Successfully built image");
         },
     );
 }

--- a/buildpacks/maven/tests/integration/misc.rs
+++ b/buildpacks/maven/tests/integration/misc.rs
@@ -117,17 +117,18 @@ fn no_internal_maven_options_logging() {
 #[test]
 #[ignore = "integration test"]
 fn descriptive_error_message_on_failed_build() {
-    TestRunner::default().build(default_build_config("test-apps/app-with-compile-error").expected_pack_result(PackResult::Failure), |context| {
+    TestRunner::default().build(
+        default_build_config("test-apps/app-with-compile-error")
+            .expected_pack_result(PackResult::Failure),
+        |context| {
             assert_contains!(context.pack_stderr, "[INFO] BUILD FAILURE");
 
-            assert_contains!(
-                context.pack_stderr,
-                "[Error: Unexpected Maven exit code]"
-            );
+            assert_contains!(context.pack_stderr, "! ERROR: Unexpected Maven exit code");
 
             assert_contains!(
                 context.pack_stderr,
-                "Maven unexpectedly exited with code '1'. The most common reason for this are\nproblems with your application code and/or build configuration."
+                "Maven unexpectedly exited with code '1'. The most common reason for this are"
             );
-        });
+        },
+    );
 }

--- a/buildpacks/maven/tests/integration/polyglot.rs
+++ b/buildpacks/maven/tests/integration/polyglot.rs
@@ -7,7 +7,7 @@ fn polyglot_maven_app() {
     TestRunner::default().build(
         default_build_config("test-apps/simple-http-service-groovy-polyglot"),
         |context| {
-            assert_contains!(context.pack_stdout, "[INFO] BUILD SUCCESS");
+            assert_contains!(context.pack_stderr, "[INFO] BUILD SUCCESS");
         },
     );
 }

--- a/buildpacks/maven/tests/integration/settings_xml.rs
+++ b/buildpacks/maven/tests/integration/settings_xml.rs
@@ -31,7 +31,7 @@ fn maven_settings_url_failure() {
             |context| {
                 assert_contains!(
                     context.pack_stderr,
-                    &format!("You have set MAVEN_SETTINGS_URL to \"{SETTINGS_XML_URL_404}\". We tried to download the file at this\nURL, but the download failed. Please verify that the given URL is correct and try again.")
+                    &format!("You have set MAVEN_SETTINGS_URL to \"{SETTINGS_XML_URL_404}\". We tried to download the file at this")
                 );
 
                 // This error message comes from Maven itself. We don't expect Maven to to be executed at all.

--- a/buildpacks/maven/tests/integration/settings_xml.rs
+++ b/buildpacks/maven/tests/integration/settings_xml.rs
@@ -12,7 +12,7 @@ fn maven_settings_url_success() {
             .env("MAVEN_SETTINGS_URL", SETTINGS_XML_URL),
         |context| {
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!(
                     "[BUILDPACK INTEGRATION TEST - SETTINGS TEST VALUE] {SETTINGS_XML_URL_VALUE}"
                 )
@@ -35,7 +35,7 @@ fn maven_settings_url_failure() {
                 );
 
                 // This error message comes from Maven itself. We don't expect Maven to to be executed at all.
-                assert_not_contains!(context.pack_stdout, "[INFO] BUILD FAILURE");
+                assert_not_contains!(context.pack_stderr, "[INFO] BUILD FAILURE");
             },
         );
 }
@@ -54,7 +54,7 @@ fn maven_settings_path() {
             .env("MAVEN_SETTINGS_PATH", settings_xml_filename),
         |context| {
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!(
                     "[BUILDPACK INTEGRATION TEST - SETTINGS TEST VALUE] {settings_xml_test_value}"
                 )
@@ -79,7 +79,7 @@ fn maven_settings_path_and_settings_url() {
         |context| {
             // Assert MAVEN_SETTINGS_PATH takes precedence
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!(
                     "[BUILDPACK INTEGRATION TEST - SETTINGS TEST VALUE] {settings_xml_test_value}"
                 )
@@ -101,7 +101,7 @@ fn maven_settings_xml_in_app_root() {
         }),
         |context| {
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!(
                     "[BUILDPACK INTEGRATION TEST - SETTINGS TEST VALUE] {settings_xml_test_value}"
                 )
@@ -128,7 +128,7 @@ fn maven_settings_xml_in_app_root_and_explicit_settings_path() {
             .env("MAVEN_SETTINGS_PATH", zero_wing_filename),
         |context| {
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!(
                     "[BUILDPACK INTEGRATION TEST - SETTINGS TEST VALUE] {zero_wing_test_value}"
                 )
@@ -152,7 +152,7 @@ fn maven_settings_xml_in_app_root_and_explicit_settings_url() {
             .env("MAVEN_SETTINGS_URL", SETTINGS_XML_URL),
         |context| {
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!(
                     "[BUILDPACK INTEGRATION TEST - SETTINGS TEST VALUE] {SETTINGS_XML_URL_VALUE}"
                 )

--- a/buildpacks/maven/tests/integration/versions.rs
+++ b/buildpacks/maven/tests/integration/versions.rs
@@ -44,7 +44,7 @@ fn with_wrapper_and_unknown_system_properties() {
                 UNKNOWN_MAVEN_VERSION, &path
             )).expected_pack_result(PackResult::Failure),
             |context| {
-                assert_contains!(context.pack_stderr, "[Error: Unsupported Maven version]");
+                assert_contains!(context.pack_stderr, "! ERROR: Unsupported Maven version");
                 assert_contains!(context.pack_stderr, &format!("You have defined an unsupported Maven version ({UNKNOWN_MAVEN_VERSION}) in the system.properties file."));
             },
         );
@@ -80,7 +80,7 @@ fn without_wrapper_and_unknown_system_properties() {
                 set_maven_version_app_dir_preprocessor(UNKNOWN_MAVEN_VERSION, &path);
             }).expected_pack_result(PackResult::Failure),
             |context| {
-                assert_contains!(context.pack_stderr, "[Error: Unsupported Maven version]");
+                assert_contains!(context.pack_stderr, "! ERROR: Unsupported Maven version");
                 assert_contains!(context.pack_stderr, &format!("You have defined an unsupported Maven version ({UNKNOWN_MAVEN_VERSION}) in the system.properties file."));
             },
         );

--- a/buildpacks/maven/tests/integration/versions.rs
+++ b/buildpacks/maven/tests/integration/versions.rs
@@ -7,10 +7,10 @@ use std::path::Path;
 #[ignore = "integration test"]
 fn with_wrapper() {
     TestRunner::default().build( default_build_config("test-apps/simple-http-service"), |context| {
-            assert_not_contains!(context.pack_stdout, "  - Selected Maven version");
-            assert_contains!(context.pack_stdout, "- Skipping (Maven wrapper detected)");
-            assert_contains!(context.pack_stdout, "  - Running `./mvnw");
-            assert_contains!(context.pack_stdout, &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {SIMPLE_HTTP_SERVICE_MAVEN_WRAPPER_VERSION}"));
+            assert_not_contains!(context.pack_stderr, "  - Selected Maven version");
+            assert_contains!(context.pack_stderr, "- Skipping (Maven wrapper detected)");
+            assert_contains!(context.pack_stderr, "  - Running `./mvnw");
+            assert_contains!(context.pack_stderr, &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {SIMPLE_HTTP_SERVICE_MAVEN_WRAPPER_VERSION}"));
         });
 }
 
@@ -24,12 +24,12 @@ fn with_wrapper_and_system_properties() {
         }),
         |context| {
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!("  - Selected Maven version `{DEFAULT_MAVEN_VERSION}`")
             );
-            assert_not_contains!(context.pack_stdout, "$ ./mvnw");
+            assert_not_contains!(context.pack_stderr, "$ ./mvnw");
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {DEFAULT_MAVEN_VERSION}")
             );
         },
@@ -58,13 +58,13 @@ fn without_wrapper_and_without_system_properties() {
             remove_maven_wrapper(&path);
         }),
         |context| {
-            assert_not_contains!(context.pack_stdout, "$ ./mvnw");
+            assert_not_contains!(context.pack_stderr, "$ ./mvnw");
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!("  - Selected Maven version `{DEFAULT_MAVEN_VERSION}`")
             );
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 &format!("[BUILDPACK INTEGRATION TEST - MAVEN VERSION] {DEFAULT_MAVEN_VERSION}")
             );
         },
@@ -95,9 +95,9 @@ fn without_wrapper_and_maven_3_9_4_system_properties() {
             set_maven_version_app_dir_preprocessor("3.9.4", &path);
         }),
         |context| {
-            assert_contains!(context.pack_stdout, "  - Selected Maven version `3.9.4`");
+            assert_contains!(context.pack_stderr, "  - Selected Maven version `3.9.4`");
             assert_contains!(
-                context.pack_stdout,
+                context.pack_stderr,
                 "[BUILDPACK INTEGRATION TEST - MAVEN VERSION] 3.9.4"
             );
         },

--- a/buildpacks/sbt/src/errors.rs
+++ b/buildpacks/sbt/src/errors.rs
@@ -4,7 +4,7 @@ use crate::layers::sbt_global::SbtGlobalLayerError;
 use crate::sbt::output::SbtError;
 use crate::sbt::version::ReadSbtVersionError;
 use buildpacks_jvm_shared::log::log_please_try_again_error;
-use buildpacks_jvm_shared::output::CmdError;
+use buildpacks_jvm_shared::output::{print_error, CmdError};
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
 use libherokubuildpack::log::log_error;
@@ -58,7 +58,7 @@ pub(crate) fn log_user_errors(error: SbtBuildpackError) {
                 error
             ),
 
-            ReadSbtVersionError::MissingVersionProperty => log_error(
+            ReadSbtVersionError::MissingVersionProperty => print_error(
                 "No sbt version defined",
                 formatdoc! { "
                 Your scala project must include project/build.properties and define a value for

--- a/buildpacks/sbt/src/errors.rs
+++ b/buildpacks/sbt/src/errors.rs
@@ -4,7 +4,7 @@ use crate::layers::sbt_global::SbtGlobalLayerError;
 use crate::sbt::output::SbtError;
 use crate::sbt::version::ReadSbtVersionError;
 use buildpacks_jvm_shared::log::{log_build_tool_command_error, log_please_try_again_error};
-use buildpacks_jvm_shared::output::{print_error, CmdError};
+use buildpacks_jvm_shared::output::{print_error, print_section, print_subsection, CmdError};
 use buildpacks_jvm_shared::system_properties::ReadSystemPropertiesError;
 use indoc::formatdoc;
 use libherokubuildpack::log::log_error;
@@ -140,15 +140,18 @@ pub(crate) fn log_user_errors(error: SbtBuildpackError) {
                 }
             }
         }
-        SbtBuildpackError::MissingTaskFailedCommand(Some(SbtError::MissingTask(task_name)), _error) => log_error(
+        SbtBuildpackError::MissingTaskFailedCommand(Some(SbtError::MissingTask(task_name)), error) => {
+            print_section("Debug info:");
+            print_subsection(format!("{error}"));
+            log_error(
             "Failed to run sbt!",
             formatdoc! {"
                 It looks like your build.sbt does not have a valid '{task_name}' task. Please reference our Dev Center article for
                 information on how to create one:
 
                 https://devcenter.heroku.com/articles/scala-support#build-behavior
-            "},
-        ),
+            "});
+        },
         SbtBuildpackError::FailedCommand(error) |
         SbtBuildpackError::MissingTaskFailedCommand(_, error) => log_build_tool_command_error("Sbt", &error),
         SbtBuildpackError::DetectPhaseIoError(error) => log_please_try_again_error(

--- a/buildpacks/sbt/src/main.rs
+++ b/buildpacks/sbt/src/main.rs
@@ -23,7 +23,6 @@ use libherokubuildpack::error::on_error as on_buildpack_error;
 use std::process::Command;
 
 use buildpacks_jvm_shared::output;
-use buildpacks_jvm_shared::output::{BuildpackOutputText, BuildpackOutputTextSection};
 #[cfg(test)]
 use buildpacks_jvm_shared_test as _;
 #[cfg(test)]
@@ -105,12 +104,8 @@ impl Buildpack for SbtBuildpack {
 
         let tasks = sbt::tasks::from_config(&buildpack_configuration);
 
-        output::track_timing(|| {
+        {
             output::print_section("Running sbt build");
-            output::print_subsection(BuildpackOutputText::new(vec![
-                BuildpackOutputTextSection::regular("Running "),
-                BuildpackOutputTextSection::command(format!("sbt {}", shell_words::join(&tasks))),
-            ]));
 
             let mut command = Command::new("sbt");
             command.current_dir(&context.app_dir).args(tasks).envs(&env);
@@ -126,7 +121,7 @@ impl Buildpack for SbtBuildpack {
                     )
                 },
             )
-        })?;
+        }?;
 
         BuildResultBuilder::new().build()
     }

--- a/buildpacks/sbt/src/main.rs
+++ b/buildpacks/sbt/src/main.rs
@@ -21,6 +21,7 @@ use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack, Env, Error, Platform};
 use libherokubuildpack::error::on_error as on_buildpack_error;
 use std::process::Command;
+use std::time::Instant;
 
 use buildpacks_jvm_shared::output;
 #[cfg(test)]
@@ -59,6 +60,7 @@ impl Buildpack for SbtBuildpack {
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        let build_timer = Instant::now();
         output::print_buildpack_name("Heroku sbt Buildpack");
 
         let buildpack_configuration = read_system_properties(&context.app_dir)
@@ -123,6 +125,7 @@ impl Buildpack for SbtBuildpack {
             )
         }?;
 
+        output::print_all_done(build_timer);
         BuildResultBuilder::new().build()
     }
 

--- a/buildpacks/sbt/tests/integration/caching.rs
+++ b/buildpacks/sbt/tests/integration/caching.rs
@@ -20,11 +20,11 @@ fn test_caching_sbt_1_8_2_coursier() {
                 "[info] [launcher] getting Scala 2.12.17 (for sbt)..."
             );
             assert_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.17. Compiling..."
             );
             assert_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "[info] Non-compiled module 'compiler-bridge_2.13' for Scala 2.13.10. Compiling..."
             );
 
@@ -44,11 +44,11 @@ fn test_caching_sbt_1_8_2_coursier() {
                         "[info] [launcher] getting Scala 2.12.17 (for sbt)..."
                     );
                     assert_not_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.17. Compiling..."
             );
                     assert_not_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "[info] Non-compiled module 'compiler-bridge_2.13' for Scala 2.13.10. Compiling..."
             );
                 },
@@ -82,16 +82,16 @@ fn test_caching_sbt_1_8_2_ivy() {
                 "[info] [launcher] getting Scala 2.12.17 (for sbt)..."
             );
             assert_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.17. Compiling..."
             );
             assert_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "[info] Non-compiled module 'compiler-bridge_2.13' for Scala 2.13.10. Compiling..."
             );
 
             for dependency_download_line in dependency_download_lines {
-                assert_contains!(&context.pack_stdout, dependency_download_line);
+                assert_contains!(&context.pack_stderr, dependency_download_line);
             }
 
             context.rebuild(
@@ -110,16 +110,16 @@ fn test_caching_sbt_1_8_2_ivy() {
                         "[info] [launcher] getting Scala 2.12.17 (for sbt)..."
                     );
                     assert_not_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.17. Compiling..."
             );
                     assert_not_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "[info] Non-compiled module 'compiler-bridge_2.13' for Scala 2.13.10. Compiling..."
             );
 
                     for dependency_download_line in dependency_download_lines {
-                        assert_not_contains!(&context.pack_stdout, dependency_download_line);
+                        assert_not_contains!(&context.pack_stderr, dependency_download_line);
                     }
                 },
             );

--- a/buildpacks/sbt/tests/integration/ux.rs
+++ b/buildpacks/sbt/tests/integration/ux.rs
@@ -10,7 +10,7 @@ fn test_sbt_1_x_logging() {
         default_build_config("test-apps/sbt-1.8.2-coursier-scala-2.13.10"),
         |context| {
             assert_not_contains!(
-                &context.pack_stdout,
+                &context.pack_stderr,
                 "Executing in batch mode. For better performance use sbt's shell"
             );
         },
@@ -31,7 +31,7 @@ fn test_missing_stage_task_logging() {
         .to_owned();
 
     TestRunner::default().build(&build_config, |context| {
-        assert_contains!(&context.pack_stdout, "[error] Not a valid key: stage");
+        assert_contains!(&context.pack_stderr, "[error] Not a valid key: stage");
 
         assert_contains!(
             &context.pack_stderr,

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,3 +10,5 @@ workspace = true
 indoc = "2"
 java-properties = "2"
 libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["log", "command", "write"] }
+bullet_stream = "0.4.0"
+fun_run = { version = "0.2.0" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,6 +9,5 @@ workspace = true
 [dependencies]
 indoc = "2"
 java-properties = "2"
-libherokubuildpack = { version = "=0.26.0", default-features = false, features = ["log", "command", "write"] }
 bullet_stream = "0.4.0"
 fun_run = { version = "0.2.0" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,4 +10,4 @@ workspace = true
 indoc = "2"
 java-properties = "2"
 bullet_stream = "0.4.0"
-fun_run = { version = "0.2.0" }
+fun_run = { version = "0.4.0" }

--- a/shared/src/log.rs
+++ b/shared/src/log.rs
@@ -1,7 +1,7 @@
-use crate::output::print_error;
+use crate::output::{print_error, print_section, print_subsection};
+use fun_run::CmdError;
 use indoc::formatdoc;
 use std::fmt::Debug;
-use std::process::ExitStatus;
 
 pub fn log_please_try_again<H: AsRef<str>, M: AsRef<str>>(header: H, message: M) {
     print_error(
@@ -33,8 +33,12 @@ pub fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
     );
 }
 
-pub fn log_build_tool_unexpected_exit_code_error(build_tool_name: &str, exit_status: ExitStatus) {
-    let exit_code_string = exit_status
+pub fn log_build_tool_command_error(build_tool_name: &str, error: &CmdError) {
+    print_section("Debug info:");
+    print_subsection(format!("{error}"));
+
+    let exit_code_string = error
+        .status()
         .code()
         .map_or(String::from("<unknown>"), |code| code.to_string());
 
@@ -48,13 +52,5 @@ pub fn log_build_tool_unexpected_exit_code_error(build_tool_name: &str, exit_sta
             caused by your application, please open an issue on GitHub:
             https://github.com/heroku/buildpacks-jvm/issues/new
         " },
-    );
-}
-
-pub fn log_build_tool_io_error(build_tool_name: &str, error: std::io::Error) {
-    log_please_try_again_error(
-        "Running {build_tool_name} failed",
-        format!("An unexpected IO error occurred while running {build_tool_name}."),
-        error,
     );
 }

--- a/shared/src/log.rs
+++ b/shared/src/log.rs
@@ -1,10 +1,10 @@
+use crate::output::print_error;
 use indoc::formatdoc;
-use libherokubuildpack::log::log_error;
 use std::fmt::Debug;
 use std::process::ExitStatus;
 
 pub fn log_please_try_again<H: AsRef<str>, M: AsRef<str>>(header: H, message: M) {
-    log_error(
+    print_error(
         header,
         formatdoc! {"
             {message}
@@ -20,7 +20,7 @@ pub fn log_please_try_again_error<H: AsRef<str>, M: AsRef<str>, E: Debug>(
     message: M,
     error: E,
 ) {
-    log_error(
+    print_error(
         header,
         formatdoc! {"
             {message}
@@ -38,7 +38,7 @@ pub fn log_build_tool_unexpected_exit_code_error(build_tool_name: &str, exit_sta
         .code()
         .map_or(String::from("<unknown>"), |code| code.to_string());
 
-    log_error(
+    print_error(
         format!("Unexpected {build_tool_name} exit code"),
         formatdoc! { "
             {build_tool_name} unexpectedly exited with code '{exit_code_string}'. The most common reason for this are

--- a/shared/src/output.rs
+++ b/shared/src/output.rs
@@ -16,6 +16,10 @@ pub fn print_subsection(text: impl Into<BuildpackOutputText>) {
     print::sub_bullet(text.into().to_ansi_string());
 }
 
+pub fn print_all_done(timer: Instant) {
+    print::all_done(&Some(timer));
+}
+
 pub fn print_timing_done_subsection(duration: &Duration) {
     println!("{ANSI_RESET_CODE}  - Done ({})", format_duration(duration));
 }

--- a/shared/src/output.rs
+++ b/shared/src/output.rs
@@ -217,16 +217,12 @@ impl From<Vec<BuildpackOutputTextSection>> for BuildpackOutputText {
     }
 }
 
-pub fn track_timing<F, E, T>(f: F) -> Result<E, T>
+pub fn track_timing_subsection<F, E>(title: impl Into<BuildpackOutputText>, f: F) -> E
 where
-    F: FnOnce() -> Result<E, T>,
+    F: FnOnce() -> E,
 {
-    let start_time = Instant::now();
-    let ret = f();
-    let end_time = Instant::now();
-
-    print_timing_done_subsection(&end_time.duration_since(start_time));
-    ret
+    let _timer = print::sub_start_timer(title.into().to_ansi_string());
+    f()
 }
 
 fn format_duration(duration: &Duration) -> String {

--- a/shared/src/output.rs
+++ b/shared/src/output.rs
@@ -39,7 +39,7 @@ pub fn print_error(title: impl AsRef<str>, body: impl Into<BuildpackOutputText>)
 }
 
 pub fn run_command(mut command: Command, quiet: bool) -> Result<Output, CmdError> {
-    let title = format!("Running {}", style::value(command.name()));
+    let title = format!("Running {}", style::command(command.name()));
     if quiet {
         let timer = print::sub_start_timer(title);
         let output = command.named_output();

--- a/shared/src/output.rs
+++ b/shared/src/output.rs
@@ -41,8 +41,10 @@ pub fn print_error(title: impl AsRef<str>, body: impl Into<BuildpackOutputText>)
 pub fn run_command(mut command: Command, quiet: bool) -> Result<Output, CmdError> {
     let title = format!("Running {}", style::value(command.name()));
     if quiet {
-        let _timer = print::sub_start_timer(title);
-        command.named_output()
+        let timer = print::sub_start_timer(title);
+        let output = command.named_output();
+        let _ = timer.done();
+        output
     } else {
         print::sub_stream_with(&title, |stdout, stderr| {
             command.stream_output(stdout, stderr)
@@ -210,8 +212,10 @@ pub fn track_timing_subsection<F, E>(title: impl Into<BuildpackOutputText>, f: F
 where
     F: FnOnce() -> E,
 {
-    let _timer = print::sub_start_timer(title.into().to_ansi_string());
-    f()
+    let timer = print::sub_start_timer(title.into().to_ansi_string());
+    let output = f();
+    let _ = timer.done();
+    output
 }
 
 const VALUE_DELIMITER_CHAR: char = '`';


### PR DESCRIPTION
This is a proof of concept to see how difficult slotting in the bullet stream functions and fun run for the JVM buildpack would be.

This preserves `Into<BuildpackOutputText>` but replaces all `println!` functionality. The `track_timing` interface was changed as well as the command execution function. It could be removed all-together now as it's not doing much.