### PR TITLE
Fix lint errors on newer Rust

### DIFF
--- a/buildpacks/jvm-function-invoker/src/error.rs
+++ b/buildpacks/jvm-function-invoker/src/error.rs
@@ -112,5 +112,5 @@ pub(crate) fn handle_buildpack_error(error: JvmFunctionInvokerBuildpackError) {
                 "},
             ),
         },
-    };
+    }
 }

--- a/buildpacks/jvm-function-invoker/src/layers/bundle.rs
+++ b/buildpacks/jvm-function-invoker/src/layers/bundle.rs
@@ -57,7 +57,7 @@ pub(crate) fn handle_bundle(
         Some(2) => Err(BundleLayerError::MultipleFunctionsFound)?,
         Some(code) => Err(BundleLayerError::DetectionFailed(code))?,
         None => Err(BundleLayerError::UnexpectedDetectionTermination)?,
-    };
+    }
 
     Ok(())
 }

--- a/buildpacks/jvm/src/bin/heroku_database_env_var_rewrite.rs
+++ b/buildpacks/jvm/src/bin/heroku_database_env_var_rewrite.rs
@@ -42,7 +42,7 @@ fn jvm_env_vars_for_env(
         // Handling for Spring specific JDBC environment variables
         let disable_spring_datasource_url = input
             .get("DISABLE_SPRING_DATASOURCE_URL")
-            .map_or(false, |value| value == "true");
+            .is_some_and(|value| value == "true");
 
         if !disable_spring_datasource_url
             && !input.contains_key("SPRING_DATASOURCE_URL")
@@ -124,7 +124,7 @@ fn env_vars_for_database_url(
         url.set_scheme("postgresql")
             .map_err(|()| DatabaseEnvVarError::CannotSetScheme)?;
         url.query_pairs_mut().append_pair("sslmode", "require");
-    };
+    }
 
     Ok(HashMap::from([
         (

--- a/shared-test/src/lib.rs
+++ b/shared-test/src/lib.rs
@@ -49,7 +49,6 @@ where
                 None | Some(None) => return result,
                 Some(Some(backoff_duration)) => {
                     std::thread::sleep(backoff_duration);
-                    continue;
                 }
             },
         }


### PR DESCRIPTION
Fixes:

```
warning: this `continue` expression is redundant
  --> shared-test/src/lib.rs:52:21
   |
52 |                     continue;
   |                     ^^^^^^^^
   |
   = help: consider dropping the `continue` expression
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue
   = note: `-W clippy::needless-continue` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::needless_continue)]`

warning: unnecessary semicolon
   --> buildpacks/jvm-function-invoker/src/error.rs:115:6
    |
115 |     };
    |      ^ help: remove
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon
    = note: `-W clippy::unnecessary-semicolon` implied by `-W clippy::pedantic`
    = help: to override `-W clippy::pedantic` add `#[allow(clippy::unnecessary_semicolon)]`

warning: unnecessary semicolon
  --> buildpacks/jvm-function-invoker/src/layers/bundle.rs:60:6
   |
60 |     };
   |      ^ help: remove
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon

warning: `buildpacks-jvm-shared-test` (lib) generated 1 warning
warning: `buildpacks-jvm-shared-test` (lib test) generated 1 warning (1 duplicate)
warning: `buildpack-heroku-jvm-function-invoker` (bin "buildpack-heroku-jvm-function-invoker") generated 2 warnings (run `cargo clippy --fix --bin "buildpack-heroku-jvm-function-invoker"` to apply 2 suggestions)
warning: this `map_or` can be simplified
  --> buildpacks/jvm/src/bin/heroku_database_env_var_rewrite.rs:43:45
   |
43 |           let disable_spring_datasource_url = input
   |  _____________________________________________^
44 | |             .get("DISABLE_SPRING_DATASOURCE_URL")
45 | |             .map_or(false, |value| value == "true");
   | |___________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
   = note: `#[warn(clippy::unnecessary_map_or)]` on by default
help: use is_some_and instead
   |
45 -             .map_or(false, |value| value == "true");
45 +             .is_some_and(|value| value == "true");
   |

warning: unnecessary semicolon
   --> buildpacks/jvm/src/bin/heroku_database_env_var_rewrite.rs:127:6
    |
127 |     };
    |      ^ help: remove
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon
    = note: `-W clippy::unnecessary-semicolon` implied by `-W clippy::pedantic`
    = help: to override `-W clippy::pedantic` add `#[allow(clippy::unnecessary_semicolon)]`
```