### PR TITLE
Remove testing for heroku-20 based builders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,16 +78,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: [ "builder:24", "builder:22", "builder:20" ]
+        builder: [ "builder:24", "builder:22" ]
         arch: [ "amd64", "arm64" ]
         buildpack-directory: [ "buildpacks/gradle", "buildpacks/jvm", "buildpacks/jvm-function-invoker", "buildpacks/maven", "buildpacks/sbt" ]
         exclude:
           - builder: "builder:22"
             arch: "arm64"
-          - builder: "builder:20"
-            arch: "arm64"
-          - buildpack-directory: "buildpacks/jvm-function-invoker"
-            builder: "builder:20"
           - buildpack-directory: "buildpacks/jvm-function-invoker"
             builder: "builder:24"
     env:


### PR DESCRIPTION
Since Heroku-20 is has reached end-of-life:
https://devcenter.heroku.com/changelog-items/3230
