### PR TITLE
Remove Gradle home from launch image

### DIFF
--- a/buildpacks/gradle/CHANGELOG.md
+++ b/buildpacks/gradle/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Gradle home layer (referenced by `GRADLE_USER_HOME`) is no longer available in the run image. It was accidentally included in an earlier version of the buildpack. Applications should not rely on Gradle during runtime. ([#811](https://github.com/heroku/buildpacks-jvm/pull/811))
+
 ## [6.2.1] - 2025-04-28
 
 - No changes.

--- a/buildpacks/gradle/CHANGELOG.md
+++ b/buildpacks/gradle/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Gradle home layer (referenced by `GRADLE_USER_HOME`) is no longer available in the run image. It was accidentally included in an earlier version of the buildpack. Applications should not rely on Gradle during runtime. ([#811](https://github.com/heroku/buildpacks-jvm/pull/811))
+- Gradle home layer (referenced by `GRADLE_USER_HOME`) is no longer available in the run image. It was unintentionally included in earlier versions of the buildpack. Applications should not rely on Gradle during runtime. ([#811](https://github.com/heroku/buildpacks-jvm/pull/811))
 
 ## [6.2.1] - 2025-04-28
 

--- a/buildpacks/gradle/src/layers/gradle_home.rs
+++ b/buildpacks/gradle/src/layers/gradle_home.rs
@@ -18,7 +18,7 @@ pub(crate) fn handle_gradle_home_layer(
         layer_name!("home"),
         CachedLayerDefinition {
             build: true,
-            launch: true,
+            launch: false,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
             restored_layer_action: &|_: &GenericMetadata, _| RestoredLayerAction::KeepLayer,
         },
@@ -48,7 +48,7 @@ pub(crate) fn handle_gradle_home_layer(
             .map_err(GradleBuildpackError::WriteGradlePropertiesError)?;
 
             // We're adding this empty task to all projects to ensure we have a task we can run when
-            // we start the Gradle daemon that doesn't side-effect or output anything to the console.
+            // we start the Gradle daemon that doesn't side effect or output anything to the console.
             // https://docs.gradle.org/8.3/userguide/init_scripts.html
             fs::write(
                 layer_ref.path().join("init.gradle.kts"),


### PR DESCRIPTION
The layer that contains `GRADLE_USER_HOME` was accidentally included in the run image. This layer contains, besides other things, the dependency cache. This will cause the size of the run image to be unnecessarily large. Modern frameworks copy all required dependencies into an uber-jar and should an application need those dependencies at runtime they should be copied during the build to an appropriate directory.

This behaviour is in line with Heroku's classic buildpack for Gradle.

## Changelog
### Changed

- Gradle home layer (referenced by `GRADLE_USER_HOME`) is no longer available in the run image. It was accidentally included in an earlier version of the buildpack. Applications should not rely on Gradle during runtime. ([#811](https://github.com/heroku/buildpacks-jvm/pull/811))

[GUS-W-18528277](https://gus.lightning.force.com/a07EE00002ET05PYAT)
