### PR TITLE
Update CODEOWNERS for `inventory.json`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,6 @@ buildpack.toml @Malax
 CHANGELOG.md @Malax
 Cargo.toml @Malax
 Cargo.lock @Malax
+inventory.json @Malax
 pom.xml @Malax
 /.github/workflows/ @Malax


### PR DESCRIPTION
So that review from PRs like #818 are requested from the language owner, rather than the whole team.

This is the CNB equivalent of https://github.com/heroku/heroku-buildpack-jvm-common/pull/375.