### PR TITLE
Fix `clippy::needless-for-each` failures with Rust 1.89

### DIFF
--- a/buildpacks/sbt/src/sbt/tasks.rs
+++ b/buildpacks/sbt/src/sbt/tasks.rs
@@ -8,15 +8,15 @@ pub(crate) fn from_config(build_config: &SbtBuildpackConfiguration) -> Vec<Strin
     }
 
     if let Some(sbt_pre_tasks) = &build_config.sbt_pre_tasks {
-        sbt_pre_tasks
-            .iter()
-            .for_each(|task| tasks.push(task.to_string()));
+        for task in sbt_pre_tasks {
+            tasks.push(task.to_string());
+        }
     }
 
     if let Some(sbt_tasks) = &build_config.sbt_tasks {
-        sbt_tasks
-            .iter()
-            .for_each(|task| tasks.push(task.to_string()));
+        for task in sbt_tasks {
+            tasks.push(task.to_string());
+        }
     } else {
         let default_tasks = vec![String::from("compile"), String::from("stage")];
         for default_task in &default_tasks {


### PR DESCRIPTION
```
error: needless use of `for_each`
  --> buildpacks/sbt/src/sbt/tasks.rs:11:9
   |
11 | /         sbt_pre_tasks
12 | |             .iter()
13 | |             .for_each(|task| tasks.push(task.to_string()));
   | |___________________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each
   = note: `-D clippy::needless-for-each` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_for_each)]`
help: try
   |
11 ~         for task in sbt_pre_tasks
12 +             .iter() { tasks.push(task.to_string()); }
   |

error: needless use of `for_each`
  --> buildpacks/sbt/src/sbt/tasks.rs:17:9
   |
17 | /         sbt_tasks
18 | |             .iter()
19 | |             .for_each(|task| tasks.push(task.to_string()));
   | |___________________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each
help: try
   |
17 ~         for task in sbt_tasks
18 +             .iter() { tasks.push(task.to_string()); }
   |
```

Fixes #830.
GUS-W-19326887.