### PR TITLE
Correct the OpenJDK inventory filename in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,11 @@
 # However, request review from the language owner instead for files that are updated
 # by Dependabot or release automation, to reduce team review request noise.
 /buildpacks/*/test-apps/heroku-*-getting-started @Malax
+/buildpacks/jvm/openjdk_inventory.toml @Malax
 /buildpacks/sbt/sbt-extras @Malax
 buildpack.toml @Malax
 CHANGELOG.md @Malax
 Cargo.toml @Malax
 Cargo.lock @Malax
-inventory.json @Malax
 pom.xml @Malax
 /.github/workflows/ @Malax


### PR DESCRIPTION
Since `inventory.json` doesn't exist.

Ensures the correct reviewer is set for PRs like #840.