### PR TITLE
Fix tests for CNB lifecycle version 0.20.13

### DIFF
--- a/buildpacks/jvm/tests/integration/versions.rs
+++ b/buildpacks/jvm/tests/integration/versions.rs
@@ -16,7 +16,7 @@ fn openjdk_default() {
         ]),
         |context| {
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 &formatdoc! {"
                     ! WARNING: No OpenJDK version specified
                     ! 
@@ -52,7 +52,7 @@ fn openjdk_functions_default() {
             BuildpackReference::WorkspaceBuildpack(buildpack_id!("heroku/maven")),
         ]),
         |context| {
-            assert_not_contains!(context.pack_stderr, "No OpenJDK version specified");
+            assert_not_contains!(context.pack_stdout, "No OpenJDK version specified");
 
             assert_contains!(
                 context.run_shell_command("java -version").stderr,

--- a/buildpacks/maven/tests/integration/misc.rs
+++ b/buildpacks/maven/tests/integration/misc.rs
@@ -121,12 +121,12 @@ fn descriptive_error_message_on_failed_build() {
             assert_contains!(context.pack_stdout, "[INFO] BUILD FAILURE");
 
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 "! ERROR: Unexpected Maven exit code"
             );
 
             assert_contains!(
-                context.pack_stderr,
+                context.pack_stdout,
                 "! Maven unexpectedly exited with code '1'. The most common reason for this are\n! problems with your application code and/or build configuration."
             );
         });

--- a/buildpacks/maven/tests/integration/settings_xml.rs
+++ b/buildpacks/maven/tests/integration/settings_xml.rs
@@ -30,7 +30,7 @@ fn maven_settings_url_failure() {
                 .expected_pack_result(PackResult::Failure),
             |context| {
                 assert_contains!(
-                    context.pack_stderr,
+                    context.pack_stdout,
                     &format!("! You have set MAVEN_SETTINGS_URL to \"{SETTINGS_XML_URL_404}\". We tried to download the file at this\n! URL, but the download failed. Please verify that the given URL is correct and try again.")
                 );
 

--- a/buildpacks/maven/tests/integration/versions.rs
+++ b/buildpacks/maven/tests/integration/versions.rs
@@ -44,8 +44,8 @@ fn with_wrapper_and_unknown_system_properties() {
                 UNKNOWN_MAVEN_VERSION, &path
             )).expected_pack_result(PackResult::Failure),
             |context| {
-                assert_contains!(context.pack_stderr, "! ERROR: Unsupported Maven version");
-                assert_contains!(context.pack_stderr, &format!("! You have defined an unsupported Maven version ({UNKNOWN_MAVEN_VERSION}) in the system.properties file."));
+                assert_contains!(context.pack_stdout, "! ERROR: Unsupported Maven version");
+                assert_contains!(context.pack_stdout, &format!("! You have defined an unsupported Maven version ({UNKNOWN_MAVEN_VERSION}) in the system.properties file."));
             },
         );
 }
@@ -80,8 +80,8 @@ fn without_wrapper_and_unknown_system_properties() {
                 set_maven_version_app_dir_preprocessor(UNKNOWN_MAVEN_VERSION, &path);
             }).expected_pack_result(PackResult::Failure),
             |context| {
-                assert_contains!(context.pack_stderr, "! ERROR: Unsupported Maven version");
-                assert_contains!(context.pack_stderr, &format!("! You have defined an unsupported Maven version ({UNKNOWN_MAVEN_VERSION}) in the system.properties file."));
+                assert_contains!(context.pack_stdout, "! ERROR: Unsupported Maven version");
+                assert_contains!(context.pack_stdout, &format!("! You have defined an unsupported Maven version ({UNKNOWN_MAVEN_VERSION}) in the system.properties file."));
             },
         );
 }

--- a/buildpacks/sbt/tests/integration/caching.rs
+++ b/buildpacks/sbt/tests/integration/caching.rs
@@ -10,13 +10,13 @@ fn test_caching_sbt_1_8_2_coursier() {
     TestRunner::default().build(
         default_build_config("test-apps/sbt-1.8.2-coursier-scala-2.13.10"),
         |context| {
-            assert_contains!(&context.pack_stderr, "Downloading sbt launcher for 1.8.2:");
+            assert_contains!(&context.pack_stdout, "Downloading sbt launcher for 1.8.2:");
             assert_contains!(
-                &context.pack_stderr,
+                &context.pack_stdout,
                 "[info] [launcher] getting org.scala-sbt sbt 1.8.2  (this may take some time)..."
             );
             assert_contains!(
-                &context.pack_stderr,
+                &context.pack_stdout,
                 "[info] [launcher] getting Scala 2.12.17 (for sbt)..."
             );
             assert_contains!(
@@ -32,15 +32,15 @@ fn test_caching_sbt_1_8_2_coursier() {
                 default_build_config("test-apps/sbt-1.8.2-coursier-scala-2.13.10"),
                 |context| {
                     assert_not_contains!(
-                        &context.pack_stderr,
+                        &context.pack_stdout,
                         "Downloading sbt launcher for 1.8.2:"
                     );
                     assert_not_contains!(
-                &context.pack_stderr,
+                &context.pack_stdout,
                 "[info] [launcher] getting org.scala-sbt sbt 1.8.2  (this may take some time)..."
             );
                     assert_not_contains!(
-                        &context.pack_stderr,
+                        &context.pack_stdout,
                         "[info] [launcher] getting Scala 2.12.17 (for sbt)..."
                     );
                     assert_not_contains!(
@@ -72,13 +72,13 @@ fn test_caching_sbt_1_8_2_ivy() {
     TestRunner::default().build(
         default_build_config("test-apps/sbt-1.8.2-ivy-scala-2.13.10"),
         |context| {
-            assert_contains!(&context.pack_stderr, "Downloading sbt launcher for 1.8.2:");
+            assert_contains!(&context.pack_stdout, "Downloading sbt launcher for 1.8.2:");
             assert_contains!(
-                &context.pack_stderr,
+                &context.pack_stdout,
                 "[info] [launcher] getting org.scala-sbt sbt 1.8.2  (this may take some time)..."
             );
             assert_contains!(
-                &context.pack_stderr,
+                &context.pack_stdout,
                 "[info] [launcher] getting Scala 2.12.17 (for sbt)..."
             );
             assert_contains!(
@@ -98,15 +98,15 @@ fn test_caching_sbt_1_8_2_ivy() {
                 default_build_config("test-apps/sbt-1.8.2-ivy-scala-2.13.10"),
                 |context| {
                     assert_not_contains!(
-                        &context.pack_stderr,
+                        &context.pack_stdout,
                         "Downloading sbt launcher for 1.8.2:"
                     );
                     assert_not_contains!(
-                &context.pack_stderr,
+                &context.pack_stdout,
                 "[info] [launcher] getting org.scala-sbt sbt 1.8.2  (this may take some time)..."
             );
                     assert_not_contains!(
-                        &context.pack_stderr,
+                        &context.pack_stdout,
                         "[info] [launcher] getting Scala 2.12.17 (for sbt)..."
                     );
                     assert_not_contains!(

--- a/buildpacks/sbt/tests/integration/ux.rs
+++ b/buildpacks/sbt/tests/integration/ux.rs
@@ -34,7 +34,7 @@ fn test_missing_stage_task_logging() {
         assert_contains!(&context.pack_stdout, "[error] Not a valid key: stage");
 
         assert_contains!(
-            &context.pack_stderr,
+            &context.pack_stdout,
             "It looks like your build.sbt does not have a valid 'stage' task."
         );
     });


### PR DESCRIPTION
Fix test compatibility with CNB Lifecycle version 0.20.13 (https://github.com/buildpacks/lifecycle/releases/tag/v0.20.13).