### PR TITLE
Change OpenJDK default major version to 25

### DIFF
--- a/buildpacks/gradle/test-apps/gradle-env-test/system.properties
+++ b/buildpacks/gradle/test-apps/gradle-env-test/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=21

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Default OpenJDK major version changed from 21 to 25. This only applies if no version is specified in system.properties. ([#000](https://github.com/heroku/buildpacks-jvm/pull/000))
+- Default OpenJDK major version changed from 21 to 25. This only applies if no version is specified in system.properties. ([#844](https://github.com/heroku/buildpacks-jvm/pull/844))
 
 ## [7.0.2] - 2025-07-24
 

--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for OpenJDK 25. ([#840](https://github.com/heroku/buildpacks-jvm/pull/840))
 
+### Changed
+
+- Default OpenJDK major version changed from 21 to 25. This only applies if no version is specified in system.properties. ([#000](https://github.com/heroku/buildpacks-jvm/pull/000))
+
 ## [7.0.2] - 2025-07-24
 
 - No changes.

--- a/buildpacks/jvm/src/constants.rs
+++ b/buildpacks/jvm/src/constants.rs
@@ -1,4 +1,4 @@
 pub(crate) const JAVA_TOOL_OPTIONS_ENV_VAR_DELIMITER: &str = " ";
 pub(crate) const JAVA_TOOL_OPTIONS_ENV_VAR_NAME: &str = "JAVA_TOOL_OPTIONS";
 pub(crate) const JDK_OVERLAY_DIR_NAME: &str = ".jdk-overlay";
-pub(crate) const OPENJDK_LATEST_LTS_VERSION: u32 = 21;
+pub(crate) const OPENJDK_LATEST_LTS_VERSION: u32 = 25;

--- a/buildpacks/jvm/tests/integration/versions.rs
+++ b/buildpacks/jvm/tests/integration/versions.rs
@@ -21,7 +21,7 @@ fn openjdk_default() {
                     ! WARNING: No OpenJDK version specified
                     ! 
                     ! Your application does not explicitly specify an OpenJDK version. The latest
-                    ! long-term support (LTS) version will be installed. This currently is OpenJDK 21.
+                    ! long-term support (LTS) version will be installed. This currently is OpenJDK 25.
                     ! 
                     ! This default version will change when a new LTS version is released. Your
                     ! application might fail to build with the new version. We recommend explicitly
@@ -30,11 +30,11 @@ fn openjdk_default() {
                     ! To set the OpenJDK version, add or edit the system.properties file in the root
                     ! directory of your application to contain:
                     ! 
-                    ! java.runtime.version = 21"});
+                    ! java.runtime.version = 25"});
 
             assert_contains!(
                 context.run_shell_command("java -version").stderr,
-                "openjdk version \"21.0.8\""
+                "openjdk version \"25\""
             );
         },
     );


### PR DESCRIPTION
Default OpenJDK major version changed from `21` to `25`. This only applies if no version is specified in `system.properties`. This is in-line with the policy that the latest LTS release is always the default version installed.

Refs: 
 - https://github.com/heroku/heroku-buildpack-jvm-common/pull/396
 - GUS-W-19636327
