### PR TITLE
Remove redundant `clippy::module_name_repetitions` allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ panic_in_result_fn = "warn"
 unwrap_used = "warn"
 enum_variant_names = "allow"
 missing_errors_doc = "allow"
-module_name_repetitions = "allow"
 
 [workspace.dependencies]
 buildpacks-jvm-shared = { path = "shared" }


### PR DESCRIPTION
In several of our Rust repos we've previously had to disable the `clippy::module_name_repetitions` rule since it had too many false positives.

However, in newer Rust versions (1.84+) this rule has been moved out of the `clippy::pedantic` rule group and so is no longer enabled by default - so does not need to be manually disabled.

See:
https://rust-lang.github.io/rust-clippy/stable/index.html#module_name_repetitions
https://github.com/rust-lang/rust-clippy/commit/43e99e54fa9336e1ccc1a8a4b33f958a352f03d0

GUS-W-19674366.