### PR TITLE
Add Spring AI configuration mapping for Heroku MIA

### DIFF
--- a/buildpacks/jvm/CHANGELOG.md
+++ b/buildpacks/jvm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Support for automatic Spring AI configuration mapping from Heroku Managed Inference and Agents (MIA) environment variables. ([#000](https://github.com/heroku/buildpacks-jvm/pull/000))
+
 ## [7.0.3] - 2025-09-17
 
 ### Added


### PR DESCRIPTION
## Summary
- Extends the Spring configuration script to automatically map Heroku Managed Inference and Agents environment variables to their Spring AI equivalents
- Adds support for `INFERENCE_KEY`, `INFERENCE_URL`, and `INFERENCE_MODEL_ID` mapping to Spring AI configuration variables
- Maintains backward compatibility and follows existing disable pattern with `DISABLE_SPRING_AI_CONFIG`

GUS-W-19684879