### PR TITLE
Add heroku-26 stack support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: [ "builder:24", "builder:22" ]
+        builder: [ "builder:26", "builder:24", "builder:22" ]
         arch: [ "amd64", "arm64" ]
         buildpack-directory: [ "buildpacks/gradle", "buildpacks/jvm", "buildpacks/jvm-function-invoker", "buildpacks/maven", "buildpacks/sbt" ]
         exclude:
           - builder: "builder:22"
             arch: "arm64"
+          - buildpack-directory: "buildpacks/jvm-function-invoker"
+            builder: "builder:26"
           - buildpack-directory: "buildpacks/jvm-function-invoker"
             builder: "builder:24"
     env:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build a JVM application codebase into a production image:
 
 ```bash
 $ cd ~/workdir/sample-jvm-app
-$ pack build sample-app --builder heroku/builder:24
+$ pack build sample-app --builder heroku/builder:26
 ```
 
 Then run the image:

--- a/buildpacks/gradle/tests/integration/main.rs
+++ b/buildpacks/gradle/tests/integration/main.rs
@@ -22,7 +22,9 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => {
+            "aarch64-unknown-linux-musl"
+        }
         _ => "x86_64-unknown-linux-musl",
     };
 

--- a/buildpacks/gradle/tests/integration/main.rs
+++ b/buildpacks/gradle/tests/integration/main.rs
@@ -22,7 +22,7 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
         _ => "x86_64-unknown-linux-musl",
     };
 
@@ -40,4 +40,4 @@ fn builder() -> String {
     std::env::var("INTEGRATION_TEST_BUILDER").unwrap_or(String::from(DEFAULT_BUILDER))
 }
 
-const DEFAULT_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_BUILDER: &str = "heroku/builder:26";

--- a/buildpacks/jvm-function-invoker/tests/integration/main.rs
+++ b/buildpacks/jvm-function-invoker/tests/integration/main.rs
@@ -21,7 +21,9 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => {
+            "aarch64-unknown-linux-musl"
+        }
         _ => "x86_64-unknown-linux-musl",
     };
 

--- a/buildpacks/jvm-function-invoker/tests/integration/main.rs
+++ b/buildpacks/jvm-function-invoker/tests/integration/main.rs
@@ -21,7 +21,7 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
         _ => "x86_64-unknown-linux-musl",
     };
 
@@ -39,4 +39,4 @@ fn builder() -> String {
     std::env::var("INTEGRATION_TEST_BUILDER").unwrap_or(String::from(DEFAULT_BUILDER))
 }
 
-const DEFAULT_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_BUILDER: &str = "heroku/builder:26";

--- a/buildpacks/jvm/tests/integration/main.rs
+++ b/buildpacks/jvm/tests/integration/main.rs
@@ -21,7 +21,7 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
         _ => "x86_64-unknown-linux-musl",
     };
 
@@ -34,4 +34,4 @@ fn builder() -> String {
     std::env::var("INTEGRATION_TEST_BUILDER").unwrap_or(String::from(DEFAULT_BUILDER))
 }
 
-const DEFAULT_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_BUILDER: &str = "heroku/builder:26";

--- a/buildpacks/jvm/tests/integration/main.rs
+++ b/buildpacks/jvm/tests/integration/main.rs
@@ -21,7 +21,9 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => {
+            "aarch64-unknown-linux-musl"
+        }
         _ => "x86_64-unknown-linux-musl",
     };
 

--- a/buildpacks/maven/tests/integration/main.rs
+++ b/buildpacks/maven/tests/integration/main.rs
@@ -30,7 +30,7 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
         _ => "x86_64-unknown-linux-musl",
     };
 
@@ -47,4 +47,4 @@ fn builder() -> String {
     std::env::var("INTEGRATION_TEST_BUILDER").unwrap_or(String::from(DEFAULT_BUILDER))
 }
 
-const DEFAULT_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_BUILDER: &str = "heroku/builder:26";

--- a/buildpacks/maven/tests/integration/main.rs
+++ b/buildpacks/maven/tests/integration/main.rs
@@ -30,7 +30,9 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => {
+            "aarch64-unknown-linux-musl"
+        }
         _ => "x86_64-unknown-linux-musl",
     };
 

--- a/buildpacks/sbt/tests/integration/main.rs
+++ b/buildpacks/sbt/tests/integration/main.rs
@@ -24,7 +24,7 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
         _ => "x86_64-unknown-linux-musl",
     };
 
@@ -42,4 +42,4 @@ fn builder() -> String {
     std::env::var("INTEGRATION_TEST_BUILDER").unwrap_or(String::from(DEFAULT_BUILDER))
 }
 
-const DEFAULT_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_BUILDER: &str = "heroku/builder:26";

--- a/buildpacks/sbt/tests/integration/main.rs
+++ b/buildpacks/sbt/tests/integration/main.rs
@@ -24,7 +24,9 @@ fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => {
+            "aarch64-unknown-linux-musl"
+        }
         _ => "x86_64-unknown-linux-musl",
     };
 


### PR DESCRIPTION
Add `heroku/builder:26` to the CI integration test matrix, make it the default builder for local test runs, and update the README example accordingly.

The `jvm-function-invoker` buildpack is excluded from `builder:26` (same as `builder:24`).

GUS-W-20775995